### PR TITLE
Streamline imports

### DIFF
--- a/nrcatalogtools/catalog.py
+++ b/nrcatalogtools/catalog.py
@@ -1,4 +1,7 @@
 from abc import ABC, abstractmethod
+import os
+import sxs
+from nrcatalogtools import waveform
 
 
 class CatalogABC(ABC):
@@ -25,11 +28,6 @@ class CatalogABC(ABC):
     @abstractmethod
     def waveform_url_from_simname(self, sim_name):
         raise NotImplementedError()
-
-
-import os
-import sxs
-from . import waveform
 
 
 class CatalogBase(CatalogABC, sxs.Catalog):
@@ -78,6 +76,6 @@ class CatalogBase(CatalogABC, sxs.Catalog):
         import h5py
 
         file_path = self.waveform_filepath_from_simname(sim_name)
-        with h5py.File(file_path, 'a') as fp:
+        with h5py.File(file_path, "a") as fp:
             if attr_name not in fp.attrs:
                 fp.attrs[attr_name] = attr_value

--- a/nrcatalogtools/maya.py
+++ b/nrcatalogtools/maya.py
@@ -1,7 +1,8 @@
 import os
 import functools
 import pandas as pd
-
+import zipfile
+import collections
 from nrcatalogtools import catalog, utils
 
 
@@ -40,8 +41,6 @@ class MayaCatalog(catalog.CatalogBase):
     @classmethod
     @functools.lru_cache()
     def load(cls, download=None, verbosity=0):
-        import zipfile
-
         progress = True
         utils.maya_catalog_info["cache_dir"].mkdir(parents=True, exist_ok=True)
         catalog_url = utils.maya_catalog_info["metadata_url"]
@@ -208,8 +207,6 @@ class MayaCatalog(catalog.CatalogBase):
                 "download": row["waveform_data_link"],
             }
             file_infos[path_str] = file_info
-
-        import collections
 
         unique_files = collections.defaultdict(list)
         for k, v in file_infos.items():

--- a/nrcatalogtools/maya.py
+++ b/nrcatalogtools/maya.py
@@ -2,7 +2,7 @@ import os
 import functools
 import pandas as pd
 
-from . import catalog, utils
+from nrcatalogtools import catalog, utils
 
 
 class MayaCatalog(catalog.CatalogBase):

--- a/nrcatalogtools/rit.py
+++ b/nrcatalogtools/rit.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 import pandas as pd
 import requests
 
-from . import catalog, utils
+from nrcatalogtools import catalog, utils
 
 
 class RITCatalog(catalog.CatalogBase):

--- a/nrcatalogtools/rit.py
+++ b/nrcatalogtools/rit.py
@@ -4,8 +4,9 @@ import functools
 from tqdm import tqdm
 import pandas as pd
 import requests
-
+import collections
 from nrcatalogtools import catalog, utils
+import subprocess
 
 
 class RITCatalog(catalog.CatalogBase):
@@ -114,8 +115,6 @@ class RITCatalog(catalog.CatalogBase):
                 "download": row["waveform_data_link"],
             }
             file_infos[path_str] = file_info
-
-        import collections
 
         unique_files = collections.defaultdict(list)
         for k, v in file_infos.items():
@@ -387,7 +386,6 @@ class RITCatalogHelper(object):
         return pd.DataFrame({})
 
     def fetch_metadata(self, idx, res, id_val=-1):
-        import pandas as pd
 
         possible_file_names = [
             self.metadata_file_fmts[0].format(idx, res, id_val),
@@ -612,7 +610,6 @@ class RITCatalogHelper(object):
                 if self.verbosity > 2:
                     print("...downloading {}".format(file_path_web))
                 # wget.download(str(file_path_web), str(local_file_path))
-                import subprocess
 
                 subprocess.call(
                     [

--- a/nrcatalogtools/sxs.py
+++ b/nrcatalogtools/sxs.py
@@ -1,6 +1,6 @@
 import os
 import sxs
-from . import catalog, waveform
+from nrcatalogtools import catalog, waveform
 
 
 class SXSCatalog(catalog.CatalogBase):

--- a/nrcatalogtools/utils.py
+++ b/nrcatalogtools/utils.py
@@ -1,10 +1,10 @@
 import functools
 import pathlib
 import shutil
-
 import lal
 import requests
 import sxs
+from multiprocessing import Process, Queue
 
 nrcatalog_cache_dir = pathlib.Path("~/.cache/").expanduser().resolve()
 nr_group_tags = {}
@@ -103,7 +103,6 @@ def call_with_timeout(myfunc, args=(), kwargs={}, timeout=5):
     `timeout` seconds, the results are fetched from the `Queue` and
     returned.
     """
-    from multiprocessing import Process, Queue
 
     def funcwrapper(p, *args, **kwargs):
         """

--- a/nrcatalogtools/utils.py
+++ b/nrcatalogtools/utils.py
@@ -4,7 +4,6 @@ import shutil
 import lal
 import requests
 import sxs
-from multiprocessing import Process, Queue
 
 nrcatalog_cache_dir = pathlib.Path("~/.cache/").expanduser().resolve()
 nr_group_tags = {}
@@ -103,6 +102,8 @@ def call_with_timeout(myfunc, args=(), kwargs={}, timeout=5):
     `timeout` seconds, the results are fetched from the `Queue` and
     returned.
     """
+
+    from multiprocessing import Process, Queue
 
     def funcwrapper(p, *args, **kwargs):
         """

--- a/nrcatalogtools/waveform.py
+++ b/nrcatalogtools/waveform.py
@@ -5,7 +5,7 @@ import lal
 import numpy as np
 from sxs import WaveformModes as sxs_WaveformModes
 from nrcatalogtools.lvc import compute_phi_ref, get_nr_to_lal_rotation_angles
-from . import utils
+from nrcatalogtools import utils
 
 
 class WaveformModes(sxs_WaveformModes):

--- a/nrcatalogtools/waveform.py
+++ b/nrcatalogtools/waveform.py
@@ -1,11 +1,19 @@
 import os
-
 import h5py
 import lal
 import numpy as np
 from sxs import WaveformModes as sxs_WaveformModes
 from nrcatalogtools.lvc import compute_phi_ref, get_nr_to_lal_rotation_angles
 from nrcatalogtools import utils
+from pycbc.types import TimeSeries
+from pycbc.waveform import frequency_from_polarizations
+from scipy.interpolate import InterpolatedUnivariateSpline
+from scipy.stats import mode as stat_mode
+from sxs.waveforms.nrar import (
+    h,
+    translate_data_type_to_spin_weight,
+    translate_data_type_to_sxs_string,
+)
 
 
 class WaveformModes(sxs_WaveformModes):
@@ -80,13 +88,6 @@ class WaveformModes(sxs_WaveformModes):
             WaveformModes: Object containing time-series of SWSH modes.
         """
         import quaternionic
-        from scipy.interpolate import InterpolatedUnivariateSpline
-        from scipy.stats import mode as stat_mode
-        from sxs.waveforms.nrar import (
-            h,
-            translate_data_type_to_spin_weight,
-            translate_data_type_to_sxs_string,
-        )
 
         if type(file_path_or_open_file) == h5py._hl.files.File:
             h5_file = file_path_or_open_file
@@ -192,8 +193,6 @@ class WaveformModes(sxs_WaveformModes):
 
     @property
     def f_lower_at_1Msun(self):
-        from pycbc.types import TimeSeries
-        from pycbc.waveform import frequency_from_polarizations
 
         mode22 = self.get_mode(2, 2)
         fr22 = frequency_from_polarizations(
@@ -254,8 +253,6 @@ class WaveformModes(sxs_WaveformModes):
                 stored in `pycbc` container `TimeSeries`
         """
         if delta_t is None:
-            from scipy.stats import mode as stat_mode
-
             delta_t = stat_mode(np.diff(self.time), keepdims=True)[0][0]
         m_secs = utils.time_to_physical(total_mass)
         # we assume that we generally do not sample at a rate below 128Hz.
@@ -322,8 +319,6 @@ class WaveformModes(sxs_WaveformModes):
     def to_pycbc(self, input_array=None):
         if input_array is None:
             input_array = self
-        from pycbc.types import TimeSeries
-        from scipy.stats import mode as stat_mode
 
         delta_t = stat_mode(np.diff(input_array.time), keepdims=True)[0][0]
         return TimeSeries(


### PR DESCRIPTION
1. Does away with all relative imports
2. Imports all required packages at top-level instead of function-level

For 2 @prayush was there any reason the package was designed with many function level imports? If yes, then I can remove those changes. If not, I strongly recommend the current PR.