### PR TITLE
Add option to remove junk radiation before evaluating polarizations

### DIFF
--- a/nrcatalogtools/__init__.py
+++ b/nrcatalogtools/__init__.py
@@ -2,6 +2,7 @@
 nr-catalog-tools is a toolkit for interfacing with gravitational-wave
 catalogs generated via Numerical Relativity simulations
 """
+
 from __future__ import absolute_import
 
 from . import lvc, maya, metadata, rit, sxs, utils, waveform

--- a/nrcatalogtools/lvc.py
+++ b/nrcatalogtools/lvc.py
@@ -973,7 +973,7 @@ def get_nr_to_lal_rotation_angles(
     if abs(calpha) > 1:
         calpha_err = abs(calpha) - 1
         if calpha_err < tol:
-            # This tol could have been much smaller. 
+            # This tol could have been much smaller.
             # Just resuing the default for now.
             print(
                 f"Correcting the polarization angle for finite precision error {calpha_err}"

--- a/nrcatalogtools/rit.py
+++ b/nrcatalogtools/rit.py
@@ -40,7 +40,9 @@ class RITCatalog(catalog.CatalogBase):
         catalog_df = helper.read_metadata_df_from_disk()
         if len(catalog_df) == 0:
             if verbosity > 2:
-                print("..Catalog metadata not found on disk. Going to refresh from cache.")
+                print(
+                    "..Catalog metadata not found on disk. Going to refresh from cache."
+                )
             catalog_df = helper.refresh_metadata_df_on_disk(
                 num_sims_to_crawl=num_sims_to_crawl
             )

--- a/nrcatalogtools/sxs.py
+++ b/nrcatalogtools/sxs.py
@@ -90,14 +90,14 @@ class SXSCatalog(catalog.CatalogBase):
         if any([col not in existing_cols for col in new_cols]):
             for sim_name in metadata_dict:
                 if "metadata_location" not in existing_cols:
-                    metadata_dict[sim_name][
-                        "metadata_location"
-                    ] = self.metadata_filepath_from_simname(sim_name)
+                    metadata_dict[sim_name]["metadata_location"] = (
+                        self.metadata_filepath_from_simname(sim_name)
+                    )
                 if "metadata_link" not in existing_cols:
                     metadata_dict[sim_name]["metadata_link"] = ""
                 if "waveform_data_link" not in existing_cols:
                     metadata_dict[sim_name]["waveform_data_link"] = ""
                 if "waveform_data_location" not in existing_cols:
-                    metadata_dict[sim_name][
-                        "waveform_data_location"
-                    ] = self.waveform_filepath_from_simname(sim_name)
+                    metadata_dict[sim_name]["waveform_data_location"] = (
+                        self.waveform_filepath_from_simname(sim_name)
+                    )

--- a/nrcatalogtools/waveform.py
+++ b/nrcatalogtools/waveform.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import os
 
 import h5py
@@ -51,6 +52,7 @@ class WaveformModes(sxs_WaveformModes):
         self._t_ref_nr = None
         self._filepath = None
         self.verbosity = verbosity
+        self._modes_with_junk_removed = None
         return self
 
     @classmethod
@@ -339,6 +341,15 @@ class WaveformModes(sxs_WaveformModes):
         )
         return fr22[0] / lal.MTSUN_SI
 
+    @property
+    def modes_with_junk_removed(self):
+        if not isinstance(self._modes_with_junk_removed, sxs_WaveformModes):
+            ref_time = self.metadata["reference-time"]
+            ref_ind = np.argmin(abs(self.t - ref_time))
+            self._modes_with_junk_removed = self[ref_ind:]
+
+        return self._modes_with_junk_removed
+
     def get_polarizations(
         self, inclination, coa_phase, f_ref=None, t_ref=None, tol=1e-6
     ):
@@ -377,6 +388,7 @@ class WaveformModes(sxs_WaveformModes):
         k=3,
         kind=None,
         tol=1e-6,
+        remove_junk=True,
     ):
         """Sum over modes data and return plus and cross GW polarizations,
         rescaled appropriately for a compact-object binary with given
@@ -431,8 +443,14 @@ class WaveformModes(sxs_WaveformModes):
             t_ref=t_ref,
             tol=tol,
         )
+
+        wm_obj = self
+        if remove_junk:
+            print("Removing junk")
+            wm_obj = self.modes_with_junk_removed
+
         h = interpolate_in_amp_phase(
-            self.evaluate([angles["theta"], angles["psi"], angles["alpha"]]),
+            wm_obj.evaluate([angles["theta"], angles["psi"], angles["alpha"]]),
             new_time,
             k=k,
             kind=kind,


### PR DESCRIPTION
The current behavior in `WaveformModes.get_td_waveform` does not allow for removal of junk radiation from the data.

This PR achieves the following:
1. Removes Junk portion from WaveformModes obj before evaluating polarizations
2. Allows for a choice of Junk time.

Desirable:
1. Fetch Junk radiation time from WaveformModes obj