### PR TITLE
Install waveformtools from pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ ligo-common
 pycbc
 pandas
 sxs>=v2023.0.0
-waveformtools @ git+https://gitlab.com/vaishakp/waveformtools@main
+waveformtools
 mayawaves


### PR DESCRIPTION
I propose to remove the dependency on `waveformtools` `main` branch and rather point to pypi, along with the request that `waveformtools` releases on pypi be made more periodic (i.e. when there are sufficient amount of changes).

Additionally, it would be good to have 

- [ ] spectral https://github.com/vaishakp/spectral
- [ ] config https://gitlab.com/vaishakp/config

pip installable through pypi 