### PR TITLE
Separate simulation metadata from (sxs) metadata

### DIFF
--- a/nrcatalogtools/catalog.py
+++ b/nrcatalogtools/catalog.py
@@ -69,6 +69,8 @@ class CatalogBase(CatalogABC, sxs_Catalog):
         metadata = self.get_metadata(sim_name)
         if type(metadata) is not dict and hasattr(metadata, "to_dict"):
             metadata = metadata.to_dict()
+        elif isinstance(metadata, dict):
+            metadata = dict(metadata.items())
         return waveform.WaveformModes.load_from_h5(filepath, metadata=metadata)
 
     def get_metadata(self, sim_name):

--- a/nrcatalogtools/waveform.py
+++ b/nrcatalogtools/waveform.py
@@ -165,7 +165,6 @@ class WaveformModes(sxs_WaveformModes):
             data[:, idx] = amp_interp(times) * np.exp(1j * phase_interp(times))
 
         w_attributes = {}
-        # w_attributes["metadata"] = metadata
         w_attributes["history"] = ""
         w_attributes["frame"] = quaternionic.array([[1.0, 0.0, 0.0, 0.0]])
         w_attributes["frame_type"] = "inertial"
@@ -178,7 +177,6 @@ class WaveformModes(sxs_WaveformModes):
         )
         w_attributes["r_is_scaled_out"] = True
         w_attributes["m_is_scaled_out"] = True
-        # w_attributes["ells"] = ell_min, ell_max
 
         return cls(
             data,

--- a/nrcatalogtools/waveform.py
+++ b/nrcatalogtools/waveform.py
@@ -212,7 +212,7 @@ class WaveformModes(sxs_WaveformModes):
     @property
     def label(self):
         """Return a Latex label that summarizes key simulation details"""
-        md = self.metadata
+        md = self.sim_metadata
 
         return (
             f"$q{md['relaxed_mass_ratio_1_over_2']:0.3f}\\_"
@@ -243,7 +243,7 @@ class WaveformModes(sxs_WaveformModes):
             dict: Initial binary parameters with names compatible with PyCBC.
         """
 
-        metadata = self.metadata
+        metadata = self.sim_metadata
         parameters = md.get_source_parameters_from_metadata(
             metadata, total_mass=total_mass
         )

--- a/nrcatalogtools/waveform.py
+++ b/nrcatalogtools/waveform.py
@@ -116,9 +116,9 @@ class WaveformModes(sxs_WaveformModes):
         # it here.
 
         try:
-            cls._metadata
+            cls._sim_metadata
         except AttributeError:
-            cls._metadata = metadata
+            cls._sim_metadata = metadata
 
         ELL_MIN, ELL_MAX = 2, 10
         ell_min, ell_max = 99, -1
@@ -165,7 +165,7 @@ class WaveformModes(sxs_WaveformModes):
             data[:, idx] = amp_interp(times) * np.exp(1j * phase_interp(times))
 
         w_attributes = {}
-        w_attributes["metadata"] = metadata
+        # w_attributes["metadata"] = metadata
         w_attributes["history"] = ""
         w_attributes["frame"] = quaternionic.array([[1.0, 0.0, 0.0, 0.0]])
         w_attributes["frame_type"] = "inertial"
@@ -202,12 +202,12 @@ class WaveformModes(sxs_WaveformModes):
     @property
     def sim_metadata(self):
         """Return the simulation metadata dictionary"""
-        return self._metadata["metadata"]
+        return self._sim_metadata
 
     @property
     def metadata(self):
         """Return the simulation metadata dictionary"""
-        return self.sim_metadata
+        return self._metadata
 
     @property
     def label(self):

--- a/nrcatalogtools/waveform.py
+++ b/nrcatalogtools/waveform.py
@@ -39,6 +39,8 @@ class WaveformModes(sxs_WaveformModes):
         verbosity=0,
         **w_attributes,
     ) -> None:
+        _filepath = w_attributes.pop('filepath', None)
+        _sim_metadata = w_attributes.pop('sim_metadata', {})
         self = super().__new__(
             cls,
             data,
@@ -50,8 +52,9 @@ class WaveformModes(sxs_WaveformModes):
             **w_attributes,
         )
         self._t_ref_nr = None
-        self._filepath = None
         self.verbosity = verbosity
+        self._filepath = _filepath
+        self._sim_metadata = _sim_metadata
         return self
 
     @classmethod
@@ -111,14 +114,17 @@ class WaveformModes(sxs_WaveformModes):
         else:
             raise RuntimeError(f"Could not use or open {file_path_or_open_file}")
 
-        # Set the file path attribute
-        cls._filepath = h5_file.filename
+        w_attributes = {}
+        w_attributes['filepath'] = h5_file.filename
+        w_attributes['sim_metadata'] = metadata
+        # # Set the file path attribute
+        # cls._filepath = h5_file.filename
+        # # If _metadata is not already a set attribute, then set it here.
 
-        # If _metadata is not already a set attribute, then set it here.
-        try:
-            cls._sim_metadata
-        except AttributeError:
-            cls._sim_metadata = metadata
+        # try:
+        #     cls._sim_metadata
+        # except AttributeError:
+        #     cls._sim_metadata = metadata
 
         ell_min, ell_max = 99, -1
         LM = []
@@ -163,7 +169,6 @@ class WaveformModes(sxs_WaveformModes):
             phase_interp = InterpolatedUnivariateSpline(phase_time, phase)
             data[:, idx] = amp_interp(times) * np.exp(1j * phase_interp(times))
 
-        w_attributes = {}
         w_attributes["history"] = ""
         w_attributes["frame"] = quaternionic.array([[1.0, 0.0, 0.0, 0.0]])
         w_attributes["frame_type"] = "inertial"


### PR DESCRIPTION
This pull request aims to fix #63.

The current behaviour of the metadata in `nrcatalogtools.waveform.WaveformModes` is that after the instance is created, the simulation metadata is stored in both `self.metadata` and `self.sim_metadata`, whereas the necessary metadata needed for the internals of `sxs` (e.g. `TimeSeries` and `WaveformModes`) to work is stored in `self._metadata`.

This is the current behaviour explicitly:
```python
h_rit = rit_catalog.get('RIT:BBH:0001-n100-id3')

h_rit.metadata.keys()
> odict_keys(['Unnamed__0', 'catalog_tag', 'resolution_tag', 'id_tag', 'run_name', 'data_type',  ...
h_rit._metadata.keys()
> dict_keys(['time', 'time_axis', 'modes_axis', 'ell_min', 'ell_max', 'metadata', ...
h_rit.sim_metadata.keys()
> odict_keys(['Unnamed__0', 'catalog_tag', 'resolution_tag', 'id_tag', 'run_name', 'data_type',  ...
```

This mismatch between `metadata` and `_metadata` causes issues in operations as a `sxs.WaveformModes` or `sxs.TimeSeries`. In particular, whenever the `ndarray.view()` method is invoked (e.g. [[1](https://github.com/sxs-collaboration/sxs/blob/f44d2effdedb50c38dc8adcf8f706d118a8cd04c/sxs/time_series.py#L99)] and [[2](https://github.com/sxs-collaboration/sxs/blob/f44d2effdedb50c38dc8adcf8f706d118a8cd04c/sxs/waveforms/waveform_modes.py#L122)]), the keys in `_metadata` will be overwritten/combined with those in `metadata`, which then lead to the slicing issue in #63. 

This PR addresses this issue by creating an additional hidden attribute `_sim_metadata` to store the simulation metadata, thereby completely separate `metadata` from `sim_metadata`. 

After this PR, the behaviour should become:
```python
h_rit = rit_catalog.get('RIT:BBH:0001-n100-id3')

h_rit.metadata.keys()
> dict_keys(['time', 'time_axis', 'modes_axis', 'ell_min', 'ell_max', 'metadata', ...
h_rit._metadata.keys()
> dict_keys(['time', 'time_axis', 'modes_axis', 'ell_min', 'ell_max', 'metadata', ...
h_rit.sim_metadata.keys()
> odict_keys(['Unnamed__0', 'catalog_tag', 'resolution_tag', 'id_tag', 'run_name', 'data_type',  ...
h_rit._sim_metadata.keys()
> odict_keys(['Unnamed__0', 'catalog_tag', 'resolution_tag', 'id_tag', 'run_name', 'data_type',  ...
```