### PR TITLE
Infrastructure updates

### DIFF
--- a/nrcatalogtools/metadata.py
+++ b/nrcatalogtools/metadata.py
@@ -1,10 +1,13 @@
+import pathlib
+
 import numpy as np
+import yaml
 
 import lal
 from pycbc.pnutils import mtotal_eta_to_mass1_mass2
 
 # ---------------------------------------------------------------------------
-# Cross-catalog metadata key mappings
+# Cross-catalog metadata key mappings — loaded from YAML schemas at import time
 # ---------------------------------------------------------------------------
 # Each dict maps a canonical physical quantity name to the corresponding
 # metadata key in that catalog's raw dict.  A value of None means the
@@ -22,71 +25,32 @@ from pycbc.pnutils import mtotal_eta_to_mass1_mass2
 #   q_sxs  = metadata_sxs[SXS_KEYS["mass_ratio"]]
 #   q_maya = metadata_maya[MAYA_KEYS["mass_ratio"]]
 #
-# For quantities whose catalog key is None, see the docstring of each dict
-# for the derivation.
+# For quantities whose catalog key is None, see the per-catalog YAML file
+# (nrcatalogtools/schemas/) for the access pattern.
 # ---------------------------------------------------------------------------
 
-RIT_KEYS = {
-    # --- Identification ---
-    "simulation_id": "catalog-tag",  # e.g. "RIT:BBH:0001"
-    "resolution_tag": "resolution-tag",  # e.g. "n100"
-    "id_tag": "id-tag",  # e.g. "id3" or "ecc"
-    "run_name": "run-name",
-    "spin_config": "system-type",  # "Aligned", "Precessing", "Nonspinning"
-    # --- Masses (physical / relaxed epoch, code units M=1) ---
-    "mass1": "relaxed-mass1",
-    "mass2": "relaxed-mass2",
-    "total_mass": "relaxed-total-mass",
-    "mass_ratio": "relaxed-mass-ratio-1-over-2",  # m1/m2 >= 1
-    "mass1_initial": "initial-mass1",
-    "mass2_initial": "initial-mass2",
-    "mass_final": "final-mass",
-    # --- Spins (physical / relaxed epoch, dimensionless chi = S/m^2) ---
-    "spin1x": "relaxed-chi1x",
-    "spin1y": "relaxed-chi1y",
-    "spin1z": "relaxed-chi1z",
-    "spin2x": "relaxed-chi2x",
-    "spin2y": "relaxed-chi2y",
-    "spin2z": "relaxed-chi2z",
-    "spin1x_initial": "initial-bh-chi1x",
-    "spin1y_initial": "initial-bh-chi1y",
-    "spin1z_initial": "initial-bh-chi1z",
-    "spin2x_initial": "initial-bh-chi2x",
-    "spin2y_initial": "initial-bh-chi2y",
-    "spin2z_initial": "initial-bh-chi2z",
-    "spin_final_magnitude": "final-chi",
-    # --- Reference / relaxation epoch ---
-    "reference_time": "relaxed-time",
-    "relaxation_time": "relaxed-time",  # same key in RIT
-    # --- Orbital dynamics ---
-    "separation_initial": "initial-separation",
-    "eccentricity": "eccentricity",
-    "n_orbits": "number-of-orbits",
-    "n_cycles_22": "number-of-cycles-22",
-    # --- Frequencies (code units: M*Omega or M*f) ---
-    "freq_start_22": "freq-start-22",  # M * f_GW^(2,2) at waveform start
-    "freq_start_22_hz_1msun": "freq-start-22-Hz-1Msun",  # Hz at M_tot = 1 M_sun
-    # orbital angular momentum direction at relaxed epoch
-    "LNhat_x": "relaxed-LNhatx",
-    "LNhat_y": "relaxed-LNhaty",
-    "LNhat_z": "relaxed-LNhatz",
-    # separation unit vector at relaxed epoch
-    "nhat_x": "relaxed-nhatx",
-    "nhat_y": "relaxed-nhaty",
-    "nhat_z": "relaxed-nhatz",
-    # --- Remnant / merger ---
-    "peak_omega_22": "peak-omega-22",
-    "peak_amplitude_22": "peak-ampl-22",
-    "remnant_kick_kmps": "final-kick",  # km/s
-    # --- ADM quantities ---
-    "adm_energy_initial": "initial-ADM-energy",
-    "adm_Lmag_initial": "initial-orbital-angular-momentum",
-    # --- Numerical method ---
-    "fd_order": "fd-order",
-    "cfl": "cfl",
-    "evolution_system": "evolution-system",
-    "initial_data_type": "initial-data-type",
-}
+_SCHEMAS_DIR = pathlib.Path(__file__).parent / "schemas"
+
+
+def _load_schema(filename):
+    """Load a catalog key-mapping schema from the schemas/ directory.
+
+    Parameters
+    ----------
+    filename : str
+        YAML file name relative to ``nrcatalogtools/schemas/``.
+
+    Returns
+    -------
+    dict
+        Mapping of canonical quantity names to catalog-specific key strings
+        (or ``None`` for derived quantities).
+    """
+    with (_SCHEMAS_DIR / filename).open() as fh:
+        return yaml.safe_load(fh)
+
+
+RIT_KEYS = _load_schema("rit_keys.yaml")
 """Mapping from canonical quantity names to RIT metadata keys (hyphenated).
 
 In the `simulations_dataframe` these keys appear as-is (with hyphens).
@@ -95,62 +59,7 @@ In the `simulations_dataframe` these keys appear as-is (with hyphens).
 construction.
 """
 
-SXS_KEYS = {
-    # --- Identification ---
-    "simulation_id": "alternative_names",  # e.g. "SXS:BBH:0001"
-    "run_name": "simulation_name",  # internal directory path
-    "object_types": "object_types",  # "BHBH", "NSNS", "BHNS"
-    # --- Masses (reference epoch, code units) ---
-    "mass1": "reference_mass1",
-    "mass2": "reference_mass2",
-    "mass_ratio": "reference_mass_ratio",  # m1/m2 >= 1
-    "mass1_initial": "initial_mass1",
-    "mass2_initial": "initial_mass2",
-    "mass_final": "remnant_mass",
-    # --- Spins (reference epoch, dimensionless chi = S/m^2, 3-vectors) ---
-    # Note: SXS stores spins as 3-element lists; index [0]=x, [1]=y, [2]=z
-    "spin1_vector": "reference_dimensionless_spin1",
-    "spin2_vector": "reference_dimensionless_spin2",
-    "spin1x": None,  # reference_dimensionless_spin1[0]
-    "spin1y": None,  # reference_dimensionless_spin1[1]
-    "spin1z": None,  # reference_dimensionless_spin1[2]
-    "spin2x": None,  # reference_dimensionless_spin2[0]
-    "spin2y": None,  # reference_dimensionless_spin2[1]
-    "spin2z": None,  # reference_dimensionless_spin2[2]
-    "spin1_magnitude": "reference_chi1_mag",
-    "spin2_magnitude": "reference_chi2_mag",
-    "chi_eff": "reference_chi_eff",
-    "spin1_perp": "reference_chi1_perp",
-    "spin2_perp": "reference_chi2_perp",
-    "spin1_vector_initial": "initial_dimensionless_spin1",
-    "spin2_vector_initial": "initial_dimensionless_spin2",
-    "remnant_spin_vector": "remnant_dimensionless_spin",
-    # --- Reference / relaxation epoch ---
-    "reference_time": "reference_time",
-    "relaxation_time": "relaxation_time",
-    # --- Orbital dynamics ---
-    # orbital_frequency is a 3-vector; magnitude = M*Omega_orb;
-    # f_GW^(2,2) = |Omega| / pi  (in code units)
-    "orbital_frequency_vector": "reference_orbital_frequency",
-    "separation_initial": "initial_separation",
-    "separation_reference": "reference_separation",
-    "eccentricity": "reference_eccentricity",
-    "mean_anomaly": "reference_mean_anomaly",
-    "n_orbits": "number_of_orbits",
-    "merger_time": "common_horizon_time",
-    # --- Remnant ---
-    "remnant_kick_vector": "remnant_velocity",  # [vx,vy,vz] in units of c
-    # --- ADM quantities ---
-    "adm_energy_initial": "initial_ADM_energy",
-    "adm_angular_momentum_vector": "initial_ADM_angular_momentum",
-    "adm_linear_momentum_vector": "initial_ADM_linear_momentum",
-    "position1_initial": "initial_position1",
-    "position2_initial": "initial_position2",
-    # --- Center-of-mass correction ---
-    "com_parameters": "com_parameters",
-    # --- Numerical method ---
-    "initial_data_type": "initial_data_type",
-}
+SXS_KEYS = _load_schema("sxs_keys.yaml")
 """Mapping from canonical quantity names to SXS metadata keys (snake_case).
 
 Spin components are stored as 3-element lists under ``spin1_vector`` /
@@ -161,38 +70,7 @@ signal that they must be accessed by index::
     chi1x = spin1[0]
 """
 
-MAYA_KEYS = {
-    # --- Identification ---
-    "simulation_id": "GTID",  # e.g. "GT0001"
-    "run_name": "GT_Tag",
-    # --- Masses (code units, total mass ~ 1) ---
-    "mass1": "m1",
-    "mass2": "m2",
-    "mass1_irreducible": "m1_irr",
-    "mass2_irreducible": "m2_irr",
-    "mass_ratio": "q",  # m1/m2 >= 1
-    "eta": "eta",  # symmetric mass ratio
-    # --- Spins (dimensionless chi = S/m^2) ---
-    "spin1x": "a1x",
-    "spin1y": "a1y",
-    "spin1z": "a1z",
-    "spin2x": "a2x",
-    "spin2y": "a2y",
-    "spin2z": "a2z",
-    # --- Orbital dynamics ---
-    "separation_initial": "separation",
-    "eccentricity": "eccentricity",
-    "mean_anomaly": "mean_anomaly",
-    "merger_time": "merge_time",
-    # --- Frequencies ---
-    # omega_orbital is M*Omega_orb (code units);
-    # f_GW^(2,2) = omega_orbital / pi  (code units)
-    "orbital_frequency": "omega_orbital",
-    "freq_start_22_hz_1msun": "f_lower_at_1MSUN",  # Hz at M_tot = 1 M_sun
-    # --- File sizes ---
-    "maya_file_size_gb": "maya file size (GB)",
-    "lvcnr_file_size_gb": "lvcnr file size (GB)",
-}
+MAYA_KEYS = _load_schema("maya_keys.yaml")
 """Mapping from canonical quantity names to MAYA/GT metadata keys.
 
 Note that MAYA does not record a dedicated relaxation time, initial ADM

--- a/nrcatalogtools/rit.py
+++ b/nrcatalogtools/rit.py
@@ -33,10 +33,6 @@ class RITCatalog(catalog.CatalogBase):
         self._dict["modified"] = {}
         self._dict["records"] = {}
 
-        self.refresh_metadata_df_on_disk = self._helper.refresh_metadata_df_on_disk
-        self.download_data_for_catalog = self._helper.download_data_for_catalog
-        self.write_metadata_df_to_disk = self._helper.write_metadata_df_to_disk
-
     @classmethod
     def load(
         cls,
@@ -244,6 +240,30 @@ class RITCatalog(catalog.CatalogBase):
             + "/"
             + self.waveform_filename_from_simname(sim_name)
         )
+
+    def refresh_metadata_df_on_disk(self, num_sims_to_crawl=2000):
+        return self._helper.refresh_metadata_df_on_disk(
+            num_sims_to_crawl=num_sims_to_crawl
+        )
+
+    def download_data_for_catalog(
+        self,
+        num_sims_to_crawl=2000,
+        which_data="waveform",
+        possible_res=None,
+        max_id_in_name=-1,
+        use_cache=True,
+    ):
+        return self._helper.download_data_for_catalog(
+            num_sims_to_crawl=num_sims_to_crawl,
+            which_data=which_data,
+            possible_res=possible_res if possible_res is not None else [],
+            max_id_in_name=max_id_in_name,
+            use_cache=use_cache,
+        )
+
+    def write_metadata_df_to_disk(self):
+        return self._helper.write_metadata_df_to_disk()
 
     def download_waveform_data(self, sim_name, use_cache=None):
         return self._helper.download_waveform_data(sim_name, use_cache=use_cache)

--- a/nrcatalogtools/schemas/maya_keys.yaml
+++ b/nrcatalogtools/schemas/maya_keys.yaml
@@ -1,0 +1,40 @@
+# Mapping from canonical physical-quantity names to MAYA/GT metadata keys.
+#
+# Note that MAYA does not record a dedicated relaxation time, initial ADM
+# quantities, or a separate reference epoch distinct from the simulation start.
+
+# --- Identification ---
+simulation_id: "GTID"               # e.g. "GT0001"
+run_name: "GT_Tag"
+
+# --- Masses (code units, total mass ~ 1) ---
+mass1: "m1"
+mass2: "m2"
+mass1_irreducible: "m1_irr"
+mass2_irreducible: "m2_irr"
+mass_ratio: "q"                     # m1/m2 >= 1
+eta: "eta"                          # symmetric mass ratio
+
+# --- Spins (dimensionless chi = S/m^2) ---
+spin1x: "a1x"
+spin1y: "a1y"
+spin1z: "a1z"
+spin2x: "a2x"
+spin2y: "a2y"
+spin2z: "a2z"
+
+# --- Orbital dynamics ---
+separation_initial: "separation"
+eccentricity: "eccentricity"
+mean_anomaly: "mean_anomaly"
+merger_time: "merge_time"
+
+# --- Frequencies ---
+# omega_orbital is M*Omega_orb (code units);
+# f_GW^(2,2) = omega_orbital / pi  (code units)
+orbital_frequency: "omega_orbital"
+freq_start_22_hz_1msun: "f_lower_at_1MSUN"  # Hz at M_tot = 1 M_sun
+
+# --- File sizes ---
+maya_file_size_gb: "maya file size (GB)"
+lvcnr_file_size_gb: "lvcnr file size (GB)"

--- a/nrcatalogtools/schemas/rit_keys.yaml
+++ b/nrcatalogtools/schemas/rit_keys.yaml
@@ -1,0 +1,76 @@
+# Mapping from canonical physical-quantity names to RIT metadata keys (hyphenated).
+#
+# In the simulations_dataframe these keys appear as-is (with hyphens).
+# get_source_parameters_from_metadata() accesses them with underscores after
+# parse_metadata_txt() converts hyphens to underscores during DataFrame
+# construction.
+
+# --- Identification ---
+simulation_id: "catalog-tag"        # e.g. "RIT:BBH:0001"
+resolution_tag: "resolution-tag"    # e.g. "n100"
+id_tag: "id-tag"                    # e.g. "id3" or "ecc"
+run_name: "run-name"
+spin_config: "system-type"          # "Aligned", "Precessing", "Nonspinning"
+
+# --- Masses (physical / relaxed epoch, code units M=1) ---
+mass1: "relaxed-mass1"
+mass2: "relaxed-mass2"
+total_mass: "relaxed-total-mass"
+mass_ratio: "relaxed-mass-ratio-1-over-2"  # m1/m2 >= 1
+mass1_initial: "initial-mass1"
+mass2_initial: "initial-mass2"
+mass_final: "final-mass"
+
+# --- Spins (physical / relaxed epoch, dimensionless chi = S/m^2) ---
+spin1x: "relaxed-chi1x"
+spin1y: "relaxed-chi1y"
+spin1z: "relaxed-chi1z"
+spin2x: "relaxed-chi2x"
+spin2y: "relaxed-chi2y"
+spin2z: "relaxed-chi2z"
+spin1x_initial: "initial-bh-chi1x"
+spin1y_initial: "initial-bh-chi1y"
+spin1z_initial: "initial-bh-chi1z"
+spin2x_initial: "initial-bh-chi2x"
+spin2y_initial: "initial-bh-chi2y"
+spin2z_initial: "initial-bh-chi2z"
+spin_final_magnitude: "final-chi"
+
+# --- Reference / relaxation epoch ---
+reference_time: "relaxed-time"
+relaxation_time: "relaxed-time"     # same key in RIT
+
+# --- Orbital dynamics ---
+separation_initial: "initial-separation"
+eccentricity: "eccentricity"
+n_orbits: "number-of-orbits"
+n_cycles_22: "number-of-cycles-22"
+
+# --- Frequencies (code units: M*Omega or M*f) ---
+freq_start_22: "freq-start-22"                   # M * f_GW^(2,2) at waveform start
+freq_start_22_hz_1msun: "freq-start-22-Hz-1Msun" # Hz at M_tot = 1 M_sun
+
+# orbital angular momentum direction at relaxed epoch
+LNhat_x: "relaxed-LNhatx"
+LNhat_y: "relaxed-LNhaty"
+LNhat_z: "relaxed-LNhatz"
+
+# separation unit vector at relaxed epoch
+nhat_x: "relaxed-nhatx"
+nhat_y: "relaxed-nhaty"
+nhat_z: "relaxed-nhatz"
+
+# --- Remnant / merger ---
+peak_omega_22: "peak-omega-22"
+peak_amplitude_22: "peak-ampl-22"
+remnant_kick_kmps: "final-kick"     # km/s
+
+# --- ADM quantities ---
+adm_energy_initial: "initial-ADM-energy"
+adm_Lmag_initial: "initial-orbital-angular-momentum"
+
+# --- Numerical method ---
+fd_order: "fd-order"
+cfl: "cfl"
+evolution_system: "evolution-system"
+initial_data_type: "initial-data-type"

--- a/nrcatalogtools/schemas/sxs_keys.yaml
+++ b/nrcatalogtools/schemas/sxs_keys.yaml
@@ -1,0 +1,71 @@
+# Mapping from canonical physical-quantity names to SXS metadata keys (snake_case).
+#
+# Spin components are stored as 3-element lists under spin1_vector / spin2_vector;
+# the individual spin1x etc. entries are null to signal that they must be accessed
+# by index:
+#
+#   spin1 = metadata[SXS_KEYS["spin1_vector"]]   # [chi_x, chi_y, chi_z]
+#   chi1x = spin1[0]
+
+# --- Identification ---
+simulation_id: "alternative_names"    # e.g. "SXS:BBH:0001"
+run_name: "simulation_name"           # internal directory path
+object_types: "object_types"          # "BHBH", "NSNS", "BHNS"
+
+# --- Masses (reference epoch, code units) ---
+mass1: "reference_mass1"
+mass2: "reference_mass2"
+mass_ratio: "reference_mass_ratio"    # m1/m2 >= 1
+mass1_initial: "initial_mass1"
+mass2_initial: "initial_mass2"
+mass_final: "remnant_mass"
+
+# --- Spins (reference epoch, dimensionless chi = S/m^2, 3-vectors) ---
+# SXS stores spins as 3-element lists; index [0]=x, [1]=y, [2]=z
+spin1_vector: "reference_dimensionless_spin1"
+spin2_vector: "reference_dimensionless_spin2"
+spin1x: null                          # reference_dimensionless_spin1[0]
+spin1y: null                          # reference_dimensionless_spin1[1]
+spin1z: null                          # reference_dimensionless_spin1[2]
+spin2x: null                          # reference_dimensionless_spin2[0]
+spin2y: null                          # reference_dimensionless_spin2[1]
+spin2z: null                          # reference_dimensionless_spin2[2]
+spin1_magnitude: "reference_chi1_mag"
+spin2_magnitude: "reference_chi2_mag"
+chi_eff: "reference_chi_eff"
+spin1_perp: "reference_chi1_perp"
+spin2_perp: "reference_chi2_perp"
+spin1_vector_initial: "initial_dimensionless_spin1"
+spin2_vector_initial: "initial_dimensionless_spin2"
+remnant_spin_vector: "remnant_dimensionless_spin"
+
+# --- Reference / relaxation epoch ---
+reference_time: "reference_time"
+relaxation_time: "relaxation_time"
+
+# --- Orbital dynamics ---
+# orbital_frequency is a 3-vector; magnitude = M*Omega_orb;
+# f_GW^(2,2) = |Omega| / pi  (in code units)
+orbital_frequency_vector: "reference_orbital_frequency"
+separation_initial: "initial_separation"
+separation_reference: "reference_separation"
+eccentricity: "reference_eccentricity"
+mean_anomaly: "reference_mean_anomaly"
+n_orbits: "number_of_orbits"
+merger_time: "common_horizon_time"
+
+# --- Remnant ---
+remnant_kick_vector: "remnant_velocity"    # [vx,vy,vz] in units of c
+
+# --- ADM quantities ---
+adm_energy_initial: "initial_ADM_energy"
+adm_angular_momentum_vector: "initial_ADM_angular_momentum"
+adm_linear_momentum_vector: "initial_ADM_linear_momentum"
+position1_initial: "initial_position1"
+position2_initial: "initial_position2"
+
+# --- Center-of-mass correction ---
+com_parameters: "com_parameters"
+
+# --- Numerical method ---
+initial_data_type: "initial_data_type"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Modules to install
 
+pyyaml
 numpy
 scipy
 lalsuite

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
         package_dir={NAME: NAME},
         package_data={
             # version info
-            NAME: [write_version_file(VERSION)],
+            NAME: [write_version_file(VERSION), "schemas/*.yaml"],
             "template.data": [],
         },
         install_requires=get_requirements(),


### PR DESCRIPTION
# Move metadata key mappings to per-catalog YAML schemas

- nrcatalogtools/schemas/rit_keys.yaml — RIT key mappings (new)
- nrcatalogtools/schemas/sxs_keys.yaml — SXS key mappings with null for derived vector components (new)
- nrcatalogtools/schemas/maya_keys.yaml — MAYA/GT key mappings (new)
- metadata.py — replaced the three hardcoded Python dicts with _load_schema() calls; added import pathlib, import yaml
- setup.py — added "schemas/*.yaml" to package_data
- requirements.txt — added pyyaml

# Make RITCatalog helper delegation explicit
- Removed the three self.x = self._helper.x attribute assignments from __init__ (lines 36-38)
- Added three proper methods to RITCatalog:
    - refresh_metadata_df_on_disk(num_sims_to_crawl=2000)
    - download_data_for_catalog(num_sims_to_crawl, which_data, possible_res,
      max_id_in_name, use_cache) — also fixed the mutable-default
      possible_res=[] → None
    - write_metadata_df_to_disk()