### PR TITLE
Add catalog plugin registry

### DIFF
--- a/nrcatalogtools/__init__.py
+++ b/nrcatalogtools/__init__.py
@@ -5,10 +5,11 @@ catalogs generated via Numerical Relativity simulations
 
 from __future__ import absolute_import
 
-from . import lvc, maya, metadata, rit, sxs, utils, waveform
+from . import lvc, maya, metadata, registry, rit, sxs, utils, waveform
 from .maya import MayaCatalog
 from .rit import RITCatalog
 from .sxs import SXSCatalog
+from .registry import get_catalog, list_catalogs, register_catalog
 from .waveform import WaveformModes, apply_wigner_rotation_to_mode_dict
 from .metadata import (
     RIT_KEYS,
@@ -24,6 +25,10 @@ __all__ = [
     "MayaCatalog",
     "RITCatalog",
     "SXSCatalog",
+    # Registry
+    "register_catalog",
+    "get_catalog",
+    "list_catalogs",
     # Waveform
     "WaveformModes",
     "apply_wigner_rotation_to_mode_dict",

--- a/nrcatalogtools/maya.py
+++ b/nrcatalogtools/maya.py
@@ -4,11 +4,13 @@ import os
 import zipfile
 import pandas as pd
 from nrcatalogtools import catalog, utils
+from nrcatalogtools.registry import register_catalog
 
 # Module-level singleton — same stale-result fix as RITCatalog.
 _maya_catalog_singleton = None
 
 
+@register_catalog("MAYA")
 class MayaCatalog(catalog.CatalogBase):
     CATALOG_TYPE = "MAYA"
 

--- a/nrcatalogtools/registry.py
+++ b/nrcatalogtools/registry.py
@@ -1,0 +1,120 @@
+"""Catalog plugin registry.
+
+Provides a lightweight decorator + lookup mechanism so that new catalogs
+can be registered without editing ``__init__.py`` or any core module.
+
+Built-in registration
+---------------------
+``RITCatalog``, ``SXSCatalog``, and ``MayaCatalog`` are all registered
+automatically when the ``nrcatalogtools`` package is imported.
+
+Third-party registration
+------------------------
+A downstream package (or a user in an interactive session) can register
+an additional catalog at runtime::
+
+    from nrcatalogtools.registry import register_catalog
+    from nrcatalogtools.catalog import CatalogBase
+
+    @register_catalog("LVCNR")
+    class LVCNRCatalog(CatalogBase):
+        CATALOG_TYPE = "LVCNR"
+        ...
+
+Lookup
+------
+::
+
+    from nrcatalogtools.registry import get_catalog
+    cls = get_catalog("RIT")   # → RITCatalog
+    obj = cls.load()
+"""
+
+_REGISTRY: dict = {}
+
+
+def register_catalog(tag: str):
+    """Class decorator that registers a catalog under *tag*.
+
+    Parameters
+    ----------
+    tag : str
+        Short uppercase identifier (e.g. ``"RIT"``).  Must be unique
+        within the registry.
+
+    Returns
+    -------
+    callable
+        A class decorator; the class itself is returned unchanged so the
+        decorator can be stacked with other decorators.
+
+    Raises
+    ------
+    ValueError
+        If *tag* is already registered, to prevent silent overwrites.
+
+    Examples
+    --------
+    >>> @register_catalog("LVCNR")
+    ... class LVCNRCatalog(CatalogBase):
+    ...     CATALOG_TYPE = "LVCNR"
+    """
+
+    def decorator(cls):
+        if tag in _REGISTRY:
+            raise ValueError(
+                f"Catalog tag '{tag}' is already registered "
+                f"(by {_REGISTRY[tag].__qualname__}). "
+                "Use a different tag or unregister the existing entry first."
+            )
+        _REGISTRY[tag] = cls
+        return cls
+
+    return decorator
+
+
+def get_catalog(tag: str):
+    """Return the catalog class registered under *tag*.
+
+    Parameters
+    ----------
+    tag : str
+        Short uppercase identifier (e.g. ``"RIT"``).
+
+    Returns
+    -------
+    type
+        The registered catalog class.
+
+    Raises
+    ------
+    KeyError
+        If *tag* is not in the registry.
+
+    Examples
+    --------
+    >>> cls = get_catalog("SXS")
+    >>> catalog = cls.load()
+    """
+    if tag not in _REGISTRY:
+        known = ", ".join(sorted(_REGISTRY)) or "(none)"
+        raise KeyError(
+            f"No catalog registered under tag '{tag}'. " f"Known tags: {known}."
+        )
+    return _REGISTRY[tag]
+
+
+def list_catalogs() -> set:
+    """Return the set of all registered catalog tags.
+
+    Returns
+    -------
+    set[str]
+        Copy of the current tag set; modifying it has no effect on the registry.
+
+    Examples
+    --------
+    >>> list_catalogs()
+    {'MAYA', 'RIT', 'SXS'}
+    """
+    return set(_REGISTRY)

--- a/nrcatalogtools/rit.py
+++ b/nrcatalogtools/rit.py
@@ -10,6 +10,7 @@ import requests
 from tqdm import tqdm
 
 from nrcatalogtools import catalog, utils
+from nrcatalogtools.registry import register_catalog
 
 # Module-level singleton — avoids the stale-result bug that lru_cache caused:
 # lru_cache keyed on all arguments, so load(download=True) after an earlier
@@ -17,6 +18,7 @@ from nrcatalogtools import catalog, utils
 _rit_catalog_singleton = None
 
 
+@register_catalog("RIT")
 class RITCatalog(catalog.CatalogBase):
     CATALOG_TYPE = "RIT"
 

--- a/nrcatalogtools/sxs.py
+++ b/nrcatalogtools/sxs.py
@@ -3,11 +3,13 @@ from pathlib import Path
 
 import sxs
 from nrcatalogtools import catalog, waveform
+from nrcatalogtools.registry import register_catalog
 
 # Module-level singleton — same stale-result fix as RITCatalog.
 _sxs_catalog_singleton = None
 
 
+@register_catalog("SXS")
 class SXSCatalog(catalog.CatalogBase):
     CATALOG_TYPE = "SXS"
 


### PR DESCRIPTION
- nrcatalogtools/registry.py (new) — _REGISTRY dict, register_catalog(tag) decorator, get_catalog(tag), list_catalogs(); standalone with no intra-package imports
- rit.py, sxs.py, maya.py — each imports register_catalog and applies @register_catalog("RIT/SXS/MAYA") to its class
- nrcatalogtools/init.py — imports registry submodule and re-exports register_catalog, get_catalog, list_catalogs in __all__