### PR TITLE
WaveformModes: propagate custom attrs across slicing and copy

### DIFF
--- a/nrcatalogtools/waveform/modes.py
+++ b/nrcatalogtools/waveform/modes.py
@@ -24,6 +24,49 @@ from nrcatalogtools.waveform.units import _modal_dt
 
 
 class WaveformModes(sxs_WaveformModes):
+    """Catalog-agnostic container for spin-weighted spherical-harmonic waveform modes.
+
+    Inherits from ``sxs.WaveformModes`` (itself an ``numpy.ndarray`` subclass)
+    so that instances *are* NumPy arrays.  This is an **intentional design
+    choice**, not technical debt, motivated by three requirements:
+
+    1. **Zero-copy performance.**  Mismatch calculations (``match_single_mode``,
+       ``match_sphere_averaged``, BMS supertranslation optimization) pass mode
+       data directly to PyCBC and SciPy routines that expect array-protocol
+       objects.  Inheritance lets NumPy hand them the underlying buffer without
+       an intermediate copy.
+
+    2. **Wigner-rotation reuse.**  The parent class exposes ``evaluate()``,
+       ``index()``, ``LM``, and Wigner-D rotation infrastructure from the
+       ``sxs`` / ``spherical`` stack.  Inheriting avoids re-implementing or
+       wrapping that non-trivial mathematics.
+
+    3. **Downstream compatibility.**  Research workflows in PyCBC, ``scri``,
+       and user scripts rely on ``isinstance(wfm, sxs.WaveformModes)``
+       checks and on standard NumPy slicing semantics.  Breaking that
+       contract would impose migration costs across the gravitational-wave
+       community.
+
+    **Attribute propagation.**  Because ``numpy.ndarray`` subclasses lose
+    plain instance attributes during slicing and view-casting, all custom
+    state (``_filepath``, ``_present_modes``, ``_peak_time_22``,
+    ``_t_ref_nr``, ``verbosity``) is stored inside the ``_metadata`` dict
+    that ``sxs.TimeSeries`` already propagates.  Property descriptors
+    provide transparent read/write access.  See ``_custom_meta_keys``,
+    ``__array_finalize__``, ``__copy__``, and ``__deepcopy__`` for details.
+    """
+
+    # Custom keys stored inside ``_metadata`` so they survive the
+    # ``sxs.TimeSeries._slice`` → ``type(self)(new_data, **metadata)``
+    # reconstruction path.  Each maps to a factory producing a safe default.
+    _custom_meta_keys = {
+        "_filepath": lambda: None,
+        "_present_modes": set,
+        "_peak_time_22": lambda: None,
+        "_t_ref_nr": lambda: None,
+        "verbosity": lambda: 0,
+    }
+
     def __new__(
         cls,
         data,
@@ -35,9 +78,13 @@ class WaveformModes(sxs_WaveformModes):
         verbosity=0,
         **w_attributes,
     ) -> None:
-        # Extract _filepath before passing w_attributes to the parent so it
-        # becomes a per-instance attribute, not a class-level one.
-        filepath = w_attributes.pop("_filepath", None)
+        # Pull custom keys out of w_attributes so they don't confuse the
+        # parent constructor, then re-inject them into _metadata afterwards.
+        custom_vals = {}
+        for key in list(cls._custom_meta_keys):
+            if key in w_attributes:
+                custom_vals[key] = w_attributes.pop(key)
+
         self = super().__new__(
             cls,
             data,
@@ -48,10 +95,101 @@ class WaveformModes(sxs_WaveformModes):
             ell_max=ell_max,
             **w_attributes,
         )
-        self._t_ref_nr = None
-        self._filepath = filepath
-        self.verbosity = verbosity
+
+        # Store custom attrs inside _metadata.
+        self._metadata.setdefault("_filepath", custom_vals.get("_filepath", None))
+        self._metadata.setdefault(
+            "_present_modes", custom_vals.get("_present_modes", set())
+        )
+        self._metadata.setdefault(
+            "_peak_time_22", custom_vals.get("_peak_time_22", None)
+        )
+        self._metadata.setdefault("_t_ref_nr", custom_vals.get("_t_ref_nr", None))
+        self._metadata.setdefault("verbosity", custom_vals.get("verbosity", verbosity))
         return self
+
+    # -- Attribute-propagation machinery (REQ-3.2) -------------------------
+    #
+    # All custom state lives in ``_metadata`` so it naturally travels through
+    # the ``sxs.TimeSeries._slice`` reconstruction path.  We expose
+    # convenient instance-level accessors that read/write ``_metadata``.
+
+    @property
+    def _filepath(self):
+        return self._metadata.get("_filepath")
+
+    @_filepath.setter
+    def _filepath(self, value):
+        self._metadata["_filepath"] = value
+
+    @property
+    def _present_modes(self):
+        return self._metadata.get("_present_modes", set())
+
+    @_present_modes.setter
+    def _present_modes(self, value):
+        self._metadata["_present_modes"] = value
+
+    @property
+    def _peak_time_22(self):
+        return self._metadata.get("_peak_time_22")
+
+    @_peak_time_22.setter
+    def _peak_time_22(self, value):
+        self._metadata["_peak_time_22"] = value
+
+    @property
+    def _t_ref_nr(self):
+        return self._metadata.get("_t_ref_nr")
+
+    @_t_ref_nr.setter
+    def _t_ref_nr(self, value):
+        self._metadata["_t_ref_nr"] = value
+
+    @property
+    def verbosity(self):
+        return self._metadata.get("verbosity", 0)
+
+    @verbosity.setter
+    def verbosity(self, value):
+        self._metadata["verbosity"] = value
+
+    def __array_finalize__(self, obj):
+        """Propagate ``_metadata`` (including custom keys) from *obj*.
+
+        Delegates to the parent ``sxs.TimeSeries.__array_finalize__`` which
+        handles the core ``_metadata`` dict copy.  Then ensures our custom
+        keys have safe defaults if they were absent on the source object
+        (e.g. view-casting from a plain ndarray).
+        """
+        super().__array_finalize__(obj)
+        if obj is None:
+            return
+        for key, default_factory in self._custom_meta_keys.items():
+            self._metadata.setdefault(key, default_factory())
+
+    def __copy__(self):
+        """Shallow copy that duplicates mutable custom containers."""
+
+        result = super().__copy__()
+        # Shallow-copy mutable containers to break aliasing.
+        pm = result._metadata.get("_present_modes")
+        if isinstance(pm, (set, dict, list)):
+            result._metadata["_present_modes"] = pm.copy()
+        return result
+
+    def __deepcopy__(self, memo):
+        """Deep copy that deeply duplicates custom metadata entries."""
+        import copy as _copy_mod
+
+        result = super().__deepcopy__(memo)
+        for key in self._custom_meta_keys:
+            val = result._metadata.get(key)
+            if val is not None:
+                result._metadata[key] = _copy_mod.deepcopy(val, memo)
+        return result
+
+    # -- End attribute-propagation machinery --------------------------------
 
     @classmethod
     def _load(
@@ -624,7 +762,7 @@ class WaveformModes(sxs_WaveformModes):
     @property
     def peak_time_22(self):
         """Dimensionless time of the peak amplitude of the (2,2) mode."""
-        if hasattr(self, "_peak_time_22"):
+        if self._peak_time_22 is not None:
             return self._peak_time_22
 
         try:

--- a/test/test_waveform_attr_propagation.py
+++ b/test/test_waveform_attr_propagation.py
@@ -1,0 +1,236 @@
+"""Tests for WaveformModes attribute propagation (REQ-3.2).
+
+Verify that custom instance attributes survive slicing, copying, and
+ufunc operations on ``WaveformModes`` instances.
+"""
+
+import copy
+
+import numpy as np
+import pytest
+import quaternionic
+
+from nrcatalogtools.waveform import WaveformModes
+
+
+# ---------------------------------------------------------------------------
+# Fixture: build a minimal WaveformModes with all custom attributes set
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_wfm():
+    """Return a small WaveformModes instance with known custom attributes."""
+    n_times = 200
+    ell_min, ell_max = 2, 4
+    n_modes = sum(2 * ell + 1 for ell in range(ell_min, ell_max + 1))
+
+    times = np.linspace(0, 100, n_times)
+    data = np.random.default_rng(42).standard_normal((n_times, n_modes)) + 0j
+
+    metadata = {
+        "metadata": {
+            "catalog_type": "RIT",
+            "waveform_data_location": "/fake/path.h5",
+        }
+    }
+
+    wfm = WaveformModes(
+        data,
+        time=times,
+        time_axis=0,
+        modes_axis=1,
+        ell_min=ell_min,
+        ell_max=ell_max,
+        verbosity=3,
+        _filepath="/test/file.h5",
+        frame=quaternionic.array([[1.0, 0.0, 0.0, 0.0]]),
+        frame_type="inertial",
+        data_type="h",
+        spin_weight=-2,
+        r_is_scaled_out=True,
+        m_is_scaled_out=True,
+        **metadata,
+    )
+
+    # Set additional custom attributes that the loaders would set.
+    wfm._present_modes = {(2, 2), (2, -2), (3, 1)}
+    wfm._peak_time_22 = 55.5
+    wfm._t_ref_nr = 12.3
+    return wfm
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_attrs_match(result, original):
+    """Assert that all custom attributes on *result* match those on *original*."""
+    assert result._filepath == original._filepath
+    assert result._present_modes == original._present_modes
+    assert result._peak_time_22 == original._peak_time_22
+    assert result._t_ref_nr == original._t_ref_nr
+    assert result.verbosity == original.verbosity
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSlicing:
+    """Attributes survive NumPy/sxs slicing operations."""
+
+    def test_row_slice(self, sample_wfm):
+        """Basic time-axis slicing via sxs._slice preserves custom attrs."""
+        sliced = sample_wfm[50:150]
+        assert isinstance(sliced, WaveformModes)
+        _assert_attrs_match(sliced, sample_wfm)
+
+    def test_single_column_returns_timeseries(self, sample_wfm):
+        """Column selection drops the modes axis → sxs.TimeSeries, not WaveformModes."""
+        col = sample_wfm[:, 0]
+        # This is expected to be a TimeSeries (the modes axis is gone).
+        # We just verify it doesn't crash.
+        assert col.shape[0] == sample_wfm.shape[0]
+
+    def test_step_slice(self, sample_wfm):
+        """Step-slice preserves custom attrs."""
+        stepped = sample_wfm[::2]
+        assert isinstance(stepped, WaveformModes)
+        _assert_attrs_match(stepped, sample_wfm)
+
+
+class TestCopy:
+    """Attributes survive copy.copy and copy.deepcopy."""
+
+    def test_copy_copy(self, sample_wfm):
+        copied = copy.copy(sample_wfm)
+        assert isinstance(copied, WaveformModes)
+        _assert_attrs_match(copied, sample_wfm)
+        # Mutable containers should be separate objects.
+        assert copied._present_modes is not sample_wfm._present_modes
+
+    def test_copy_deepcopy(self, sample_wfm):
+        deep = copy.deepcopy(sample_wfm)
+        assert isinstance(deep, WaveformModes)
+        _assert_attrs_match(deep, sample_wfm)
+        assert deep._present_modes is not sample_wfm._present_modes
+
+    def test_deepcopy_independence(self, sample_wfm):
+        """Mutating the deepcopy must not affect the original."""
+        deep = copy.deepcopy(sample_wfm)
+        deep._present_modes.add((4, 4))
+        assert (4, 4) not in sample_wfm._present_modes
+
+    def test_ndarray_copy_method(self, sample_wfm):
+        """The ndarray .copy() method should propagate attributes."""
+        copied = sample_wfm.copy()
+        assert copied._filepath == sample_wfm._filepath
+        assert copied._present_modes == sample_wfm._present_modes
+        assert copied._peak_time_22 == sample_wfm._peak_time_22
+
+
+class TestUfuncAndArithmetic:
+    """Attributes survive NumPy ufunc operations when result is WaveformModes."""
+
+    def test_np_conjugate(self, sample_wfm):
+        result = np.conjugate(sample_wfm)
+        if isinstance(result, WaveformModes):
+            _assert_attrs_match(result, sample_wfm)
+
+
+class TestDefaults:
+    """When constructing from scratch, missing attributes get safe defaults."""
+
+    def test_defaults_on_fresh_instance(self):
+        """A brand-new WaveformModes without explicit custom attrs gets defaults."""
+        n_times = 50
+        ell_min, ell_max = 2, 2
+        n_modes = 5  # 2*2+1
+        times = np.linspace(0, 10, n_times)
+        data = np.zeros((n_times, n_modes), dtype=complex)
+
+        wfm = WaveformModes(
+            data,
+            time=times,
+            time_axis=0,
+            modes_axis=1,
+            ell_min=ell_min,
+            ell_max=ell_max,
+            metadata={"catalog_type": "RIT"},
+            frame=quaternionic.array([[1.0, 0.0, 0.0, 0.0]]),
+            frame_type="inertial",
+            data_type="h",
+            spin_weight=-2,
+            r_is_scaled_out=True,
+            m_is_scaled_out=True,
+        )
+        assert wfm._filepath is None
+        assert wfm._present_modes == set()
+        assert wfm._peak_time_22 is None
+        assert wfm._t_ref_nr is None
+        assert wfm.verbosity == 0
+
+
+class TestPeakTime22CacheSurvival:
+    """The cached _peak_time_22 survives slicing; lazy recomputation works."""
+
+    def test_cached_value_propagates(self, sample_wfm):
+        """If _peak_time_22 is cached, it should propagate on slice."""
+        # Force it to be cached.
+        _ = sample_wfm.peak_time_22
+        assert sample_wfm._peak_time_22 is not None
+
+        sliced = sample_wfm[10:100]
+        assert sliced._peak_time_22 == sample_wfm._peak_time_22
+
+    def test_uncached_value_computes_fresh(self):
+        """A fresh WaveformModes with _peak_time_22=None can lazily compute."""
+        n_times = 100
+        ell_min, ell_max = 2, 2
+        n_modes = 5
+        times = np.linspace(0, 50, n_times)
+        # Create data with a clear peak in the (2,2) mode.
+        data = np.zeros((n_times, n_modes), dtype=complex)
+        # LM ordering for ell_min=ell_max=2: (2,-2),(2,-1),(2,0),(2,1),(2,2)
+        # → (2,2) is at index 4
+        peak_idx = 60
+        data[:, 4] = np.exp(-((np.arange(n_times) - peak_idx) ** 2) / 50.0)
+
+        wfm = WaveformModes(
+            data,
+            time=times,
+            time_axis=0,
+            modes_axis=1,
+            ell_min=ell_min,
+            ell_max=ell_max,
+            metadata={"catalog_type": "RIT"},
+            frame=quaternionic.array([[1.0, 0.0, 0.0, 0.0]]),
+            frame_type="inertial",
+            data_type="h",
+            spin_weight=-2,
+            r_is_scaled_out=True,
+            m_is_scaled_out=True,
+        )
+        assert wfm._peak_time_22 is None  # not yet computed
+        pt = wfm.peak_time_22
+        assert pt == pytest.approx(times[peak_idx])
+        assert wfm._peak_time_22 is not None  # now cached
+
+
+class TestPresentModesSurvivesSlice:
+    """_present_modes set from load_from_targz must survive slicing."""
+
+    def test_present_modes_after_time_slice(self, sample_wfm):
+        sliced = sample_wfm[20:80]
+        assert sliced._present_modes == sample_wfm._present_modes
+
+    def test_present_modes_mutation_isolation(self, sample_wfm):
+        """Mutating _present_modes on a slice should not affect the original
+        when using copy, but MAY affect via view (since _metadata is shared)."""
+        copied = copy.copy(sample_wfm)
+        copied._present_modes.add((4, 0))
+        # After copy.copy, the sets should be independent.
+        assert (4, 0) not in sample_wfm._present_modes


### PR DESCRIPTION
Previously, custom instance attributes (_filepath, _present_modes, _peak_time_22, _t_ref_nr, verbosity) were stored as plain Python attributes on WaveformModes instances. These were silently lost during NumPy slicing (e.g. wfm[50:150]) because sxs.TimeSeries._slice reconstructs objects via type(self)(new_data, **self._metadata), discarding anything not in _metadata.

Fix by storing all custom state inside the _metadata dict that sxs.TimeSeries already propagates, with property descriptors for transparent read/write access. Add __array_finalize__ to ensure safe defaults on view-casting, and __copy__/__deepcopy__ to break aliasing of mutable containers like _present_modes.

Also fix peak_time_22 lazy-init guard: hasattr → is-not-None check, since __array_finalize__ now always sets the key.

Add class docstring documenting why inheritance from sxs.WaveformModes is an intentional design choice (zero-copy performance, Wigner-rotation reuse, downstream isinstance compatibility) rather than technical debt.

Add test/test_waveform_attr_propagation.py with 13 tests covering row slicing, step slicing, copy.copy, copy.deepcopy, ndarray.copy(), mutation isolation, ufuncs, default construction, and peak_time_22 cache survival.