### PR TITLE
Add surrogate and matching utilities

### DIFF
--- a/nrcatalogtools/__init__.py
+++ b/nrcatalogtools/__init__.py
@@ -55,6 +55,80 @@ from .metadata import (
     PYCBC_KEYS,
 )
 
+
+def load_catalog(name: str, **kwargs):
+    """Load a catalog by name tag.
+
+    Parameters
+    ----------
+    name : str
+        One of ``'SXS'``, ``'RIT'``, or ``'MAYA'`` (case-insensitive).
+    **kwargs
+        Forwarded to the catalog's ``load()`` class method.
+
+    Returns
+    -------
+    CatalogBase subclass instance
+    """
+    tag = name.upper()
+    if tag == "SXS":
+        return SXSCatalog.load(download=False, **kwargs)
+    elif tag == "RIT":
+        return RITCatalog.load(**kwargs)
+    elif tag == "MAYA":
+        return MayaCatalog.load(**kwargs)
+    else:
+        raise ValueError(f"Unknown catalog '{name}'. Supported: 'SXS', 'RIT', 'MAYA'.")
+
+
+def filter_by_surrogate_prior(
+    catalog,
+    total_mass: float = 40.0,
+    q_max: float = 4.0,
+    chi_max: float = 0.8,
+    verbose: bool = False,
+) -> list:
+    """Return the subset of simulation names within the NRSur7dq4 prior volume.
+
+    NRSur7dq4 is valid for q ∈ [1, 4] and |χ₁|, |χ₂| ≤ 0.8.  Simulations
+    whose parameters cannot be retrieved (metadata errors) are silently skipped.
+
+    Parameters
+    ----------
+    catalog : CatalogBase
+        Loaded catalog object.
+    total_mass : float, optional
+        Total mass for parameter extraction (default 40 M☉).
+    q_max : float, optional
+        Maximum allowed mass ratio (default 4).
+    chi_max : float, optional
+        Maximum allowed spin magnitude (default 0.8).
+    verbose : bool, optional
+        Print progress to stdout.
+
+    Returns
+    -------
+    list[str]
+        Simulation name tags that pass the prior cuts.
+    """
+    from .surrogate import check_surrogate_prior
+
+    passing = []
+    sims = catalog.simulations_list
+    for i, sim_name in enumerate(sims):
+        if verbose and i % 50 == 0:
+            print(f"  Checking {i}/{len(sims)}: {sim_name}")
+        try:
+            params = catalog.get_parameters(sim_name, total_mass=total_mass)
+        except Exception as exc:
+            if verbose:
+                print(f"  Skipping {sim_name}: {exc}")
+            continue
+        if check_surrogate_prior(params, q_max=q_max, chi_max=chi_max):
+            passing.append(sim_name)
+    return passing
+
+
 __all__ = [
     # Catalogs
     "MayaCatalog",
@@ -66,6 +140,9 @@ __all__ = [
     "register_catalog",
     "get_catalog",
     "list_catalogs",
+    # Catalog helpers
+    "load_catalog",
+    "filter_by_surrogate_prior",
     # Waveform
     "WaveformModes",
     "apply_wigner_rotation_to_mode_dict",

--- a/nrcatalogtools/comparisons.py
+++ b/nrcatalogtools/comparisons.py
@@ -279,7 +279,7 @@ def _plot(
     fig, axes = plt.subplots(3, 1, figsize=(10, 11))
     fig.suptitle(
         f"{catalog_name}: {sim_name}\n"
-        f"q={params['mass1']/params['mass2']:.3f}  "
+        f"q={params['mass1'] / params['mass2']:.3f}  "
         f"χ₁z={params['spin1z']:.3f}  χ₂z={params['spin2z']:.3f}  "
         f"M={total_mass} M☉",
         fontsize=11,
@@ -428,14 +428,14 @@ def _plot(
 
 def _print_table(results, sim_name):
     w = 74
-    print(f"\n{'─'*w}")
+    print(f"\n{'─' * w}")
     print(f"  Mode-by-mode comparison: {sim_name} vs NRSur7dq4")
-    print(f"{'─'*w}")
+    print(f"{'─' * w}")
     print(
         f"  {'Mode':<10} {'Match':>10}  {'ΔΦ/cycle [rad]':>16}  "
         f"{'N_cycles':>10}  {'f_lower_mode':>14}"
     )
-    print(f"{'─'*w}")
+    print(f"{'─' * w}")
     for (ell, em) in NR_MODES:
         res = results.get((ell, em), {})
         mm = res.get("match", float("nan"))
@@ -450,4 +450,4 @@ def _print_table(results, sim_name):
             f"  ({ell},{em:+d})      {mm_str:>10}  {dp_str:>16}  "
             f"{nc_str:>10}  {fl_str:>14}"
         )
-    print(f"{'─'*w}\n")
+    print(f"{'─' * w}\n")

--- a/nrcatalogtools/comparisons.py
+++ b/nrcatalogtools/comparisons.py
@@ -1,0 +1,453 @@
+"""NR vs NRSur7dq4 comparison utilities.
+
+``compare_sim_vs_surrogate`` runs the full per-mode match pipeline for a
+single simulation: loads the catalog waveform, generates surrogate modes,
+computes noise-weighted matches and phase-drift metrics, writes a CSV, and
+saves a figure.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+
+import numpy as np
+
+from .surrogate import (
+    generate_surrogate_modes,
+    check_surrogate_prior,
+    NR_MODES,
+)
+from .waveform.matching import (
+    compute_mode_match,
+    compute_phase_diff_per_cycle,
+    mode_f_lower,
+)
+
+DELTA_T = 1.0 / 4096  # seconds
+DISTANCE = 1.0  # Mpc (amplitude-irrelevant for match)
+
+
+def _safe_sim_id(sim_name: str) -> str:
+    return sim_name.replace(":", "_").replace("/", "_")
+
+
+def _waveform_duration(wfm, total_mass: float) -> float:
+    from . import utils
+
+    m_secs = utils.time_to_physical(total_mass)
+    return float(wfm.time[-1] - wfm.time[0]) * m_secs
+
+
+def compare_sim_vs_surrogate(
+    catalog_name: str,
+    sim_name: str,
+    total_mass: float = 40.0,
+    psd_name: str = "aLIGOZeroDetHighPower",
+    outdir: str | None = None,
+    figsdir: str | None = None,
+    delta_t: float = DELTA_T,
+    rotate: bool = False,
+) -> dict:
+    """Run the full NR vs NRSur7dq4 comparison for one simulation.
+
+    Parameters
+    ----------
+    catalog_name : str
+        One of ``'SXS'``, ``'RIT'``, ``'MAYA'``.
+    sim_name : str
+        Simulation identifier (e.g. ``'SXS:BBH:0001'``).
+    total_mass : float, optional
+        Total mass in solar masses (default 40).
+    psd_name : str, optional
+        PyCBC analytic PSD name (default ``'aLIGOZeroDetHighPower'``).
+    outdir : str, optional
+        Directory for the output CSV (default ``'results'`` under cwd).
+    figsdir : str, optional
+        Directory for the output figure (default ``'figs'`` under cwd).
+    delta_t : float, optional
+        Sample spacing in physical seconds (default 1/4096).
+    rotate : bool, optional
+        Also compute the SO(3)-rotation-optimized match (slow).
+
+    Returns
+    -------
+    dict
+        ``{(ell, em): {'match', 'f_lower_mode', 'phase_diff_per_cycle',
+        'n_cycles', 'match_rotated'}}``
+    """
+    if outdir is None:
+        outdir = os.path.join(os.getcwd(), "results")
+    if figsdir is None:
+        figsdir = os.path.join(os.getcwd(), "figs")
+
+    os.makedirs(outdir, exist_ok=True)
+    os.makedirs(figsdir, exist_ok=True)
+
+    # 1. Load catalog and waveform
+    from . import load_catalog
+
+    print(f"\n[1/6] Loading {catalog_name} catalog...")
+    cat = load_catalog(catalog_name)
+    print(f"      Fetching {sim_name}...")
+    wfm = cat.get(sim_name)
+
+    # 2. Extract parameters
+    print(f"[2/6] Extracting source parameters (M={total_mass} M☉)...")
+    params = cat.get_parameters(sim_name, total_mass=total_mass)
+    q = params["mass1"] / params["mass2"]
+    chi1 = np.sqrt(
+        params["spin1x"] ** 2 + params["spin1y"] ** 2 + params["spin1z"] ** 2
+    )
+    chi2 = np.sqrt(
+        params["spin2x"] ** 2 + params["spin2y"] ** 2 + params["spin2z"] ** 2
+    )
+    f_lower = params["f_lower"]
+    print(
+        f"      q={q:.4f}  |χ₁|={chi1:.4f}  |χ₂|={chi2:.4f}  f_lower={f_lower:.2f} Hz"
+    )
+
+    if not check_surrogate_prior(params):
+        print(
+            "WARNING: parameters lie outside NRSur7dq4 prior (q > 4 or |χ| > 0.8). "
+            "Proceeding, but surrogate extrapolation may be unreliable."
+        )
+
+    # 3. Generate surrogate modes
+    print(f"[3/6] Generating NRSur7dq4 modes (M={total_mass} M☉, D={DISTANCE} Mpc)...")
+    h_sur, f_lower_sur = generate_surrogate_modes(
+        params, total_mass=total_mass, distance=DISTANCE, delta_t_seconds=delta_t
+    )
+    print(f"      Generated {len(h_sur)} surrogate modes.")
+    if f_lower_sur > f_lower * 1.05:
+        print(
+            f"      NOTE: surrogate starts at f_GW={f_lower_sur:.1f} Hz "
+            f"(NRSur7dq4 minimum for these params), above NR f_lower={f_lower:.1f} Hz. "
+            f"Match f_lower raised to {f_lower_sur:.1f} Hz."
+        )
+    f_lower_match = max(f_lower, f_lower_sur)
+
+    print(f"[4/6] PSD: {psd_name} (built per-mode at matched frequency resolution)")
+
+    # 5. Per-mode match
+    print("[5/6] Computing per-mode matches...")
+    results = {}
+
+    for (ell, em) in NR_MODES:
+        try:
+            h_nr_complex = wfm.get_mode(
+                ell,
+                em,
+                total_mass=total_mass,
+                distance=DISTANCE,
+                delta_t_seconds=delta_t,
+            )
+        except Exception as exc:
+            print(f"      ({ell},{em:+d}): NR mode unavailable — {exc}")
+            results[(ell, em)] = {
+                "match": float("nan"),
+                "f_lower_mode": float("nan"),
+                "phase_diff_per_cycle": float("nan"),
+                "n_cycles": float("nan"),
+                "match_rotated": None,
+            }
+            continue
+
+        h_nr = h_nr_complex.real()
+
+        if (ell, em) not in h_sur:
+            print(f"      ({ell},{em:+d}): surrogate mode unavailable (ell > 4?)")
+            results[(ell, em)] = {
+                "match": float("nan"),
+                "f_lower_mode": float("nan"),
+                "phase_diff_per_cycle": float("nan"),
+                "n_cycles": float("nan"),
+                "match_rotated": None,
+            }
+            continue
+
+        h_sur_mode = h_sur[(ell, em)].real()
+        f_low_mode = mode_f_lower(f_lower_match, em)
+        mm = compute_mode_match(h_nr, h_sur_mode, f_low_mode, psd_name=psd_name)
+        dphase, n_cycles = compute_phase_diff_per_cycle(h_nr_complex, h_sur[(ell, em)])
+        results[(ell, em)] = {
+            "match": mm,
+            "f_lower_mode": f_low_mode,
+            "phase_diff_per_cycle": dphase,
+            "n_cycles": n_cycles,
+            "match_rotated": None,
+        }
+        flag = "" if np.isnan(mm) else f"{mm:.6f}"
+        dp_str = "N/A" if np.isnan(dphase) else f"{dphase:.4f} rad"
+        print(
+            f"      ({ell},{em:+d}): match = {flag}  phase_diff/cycle = {dp_str}"
+            f"  [f_lower_mode={f_low_mode:.1f} Hz]"
+        )
+
+    if rotate:
+        print("[5b] Computing SO(3)-rotation-optimized match (Nelder-Mead)...")
+        try:
+            from .waveform.matching import load_psd
+
+            dur_nr = _waveform_duration(wfm, total_mass)
+            dur_sur = len(next(iter(h_sur.values()))) * delta_t
+            psd_rot = load_psd(
+                f_lower_match, delta_t, max(dur_nr, dur_sur) * 1.1, psd_name=psd_name
+            )
+            mm_rot = wfm.match_sphere_averaged(
+                h_sur,
+                psd=psd_rot,
+                f_lower=f_lower_match,
+                delta_t=delta_t,
+            )
+            print(f"      SO(3)-optimized match = {mm_rot:.6f}")
+            for key in results:
+                results[key]["match_rotated"] = mm_rot
+        except Exception as exc:
+            print(f"      SO(3)-optimized match failed: {exc}")
+
+    # 6. Output
+    print(f"[6/6] Writing outputs (results to {outdir}/, figures to {figsdir}/)...")
+    _write_csv(results, sim_name, catalog_name, total_mass, params, outdir)
+    _plot(
+        results,
+        wfm,
+        h_sur,
+        sim_name,
+        catalog_name,
+        total_mass,
+        params,
+        delta_t,
+        psd_name,
+        figsdir,
+    )
+    _print_table(results, sim_name)
+
+    return results
+
+
+def _write_csv(results, sim_name, catalog_name, total_mass, params, outdir):
+    safe_id = _safe_sim_id(sim_name)
+    path = os.path.join(outdir, f"{safe_id}_mode_matches.csv")
+    rows = []
+    for (ell, em), res in results.items():
+        rows.append(
+            {
+                "sim_id": sim_name,
+                "catalog": catalog_name,
+                "total_mass": total_mass,
+                "q": params["mass1"] / params["mass2"],
+                "chi1z": params["spin1z"],
+                "chi2z": params["spin2z"],
+                "ell": ell,
+                "em": em,
+                "match": res["match"],
+                "f_lower_mode": res["f_lower_mode"],
+                "phase_diff_per_cycle": res["phase_diff_per_cycle"],
+                "n_cycles": res["n_cycles"],
+                "match_rotated": res["match_rotated"]
+                if res["match_rotated"] is not None
+                else "",
+            }
+        )
+    fieldnames = list(rows[0].keys())
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"      CSV written: {path}")
+
+
+def _plot(
+    results,
+    wfm,
+    h_sur,
+    sim_name,
+    catalog_name,
+    total_mass,
+    params,
+    delta_t,
+    psd_name,
+    outdir,
+):
+    """3-panel figure: (2,2) amplitude, (2,2) phase near merger, match bar chart."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, axes = plt.subplots(3, 1, figsize=(10, 11))
+    fig.suptitle(
+        f"{catalog_name}: {sim_name}\n"
+        f"q={params['mass1']/params['mass2']:.3f}  "
+        f"χ₁z={params['spin1z']:.3f}  χ₂z={params['spin2z']:.3f}  "
+        f"M={total_mass} M☉",
+        fontsize=11,
+    )
+
+    ax = axes[0]
+    h22_nr = None
+    try:
+        h22_nr = wfm.get_mode(
+            2, 2, total_mass=total_mass, distance=DISTANCE, delta_t_seconds=delta_t
+        )
+    except Exception:
+        pass
+
+    h22_sur = h_sur.get((2, 2))
+
+    if h22_nr is not None and h22_sur is not None:
+        t_start = max(float(h22_nr.start_time), float(h22_sur.start_time))
+        t_end = min(float(h22_nr.end_time), float(h22_sur.end_time))
+        if t_end > t_start:
+            h22_nr = h22_nr.time_slice(t_start, t_end)
+            h22_sur = h22_sur.time_slice(t_start, t_end)
+
+    if h22_nr is not None:
+        t_nr = np.array(h22_nr.sample_times)
+        ax.plot(
+            t_nr, np.abs(np.array(h22_nr)), color="C0", lw=1.5, label="NR", alpha=0.9
+        )
+
+    if h22_sur is not None:
+        t_sur = np.array(h22_sur.sample_times)
+        ax.plot(
+            t_sur,
+            np.abs(np.array(h22_sur)),
+            color="C1",
+            lw=1.5,
+            ls="--",
+            label="NRSur7dq4",
+            alpha=0.9,
+        )
+
+    ax.set_xlabel("t - t_peak [s]")
+    ax.set_ylabel("|h₂₂| [strain]")
+    ax.set_title("(2,2) mode amplitude")
+    ax.legend(fontsize=9)
+    ax.set_xlim(left=max(-2.0, ax.get_xlim()[0]))
+
+    ax = axes[1]
+    h22_sur_aligned = None
+    try:
+        t_nr_full = np.array(h22_nr.sample_times)
+        re_nr = np.array(h22_nr.real())
+        mask = t_nr_full >= -0.25
+        ax.plot(t_nr_full[mask], re_nr[mask], color="C0", lw=1.2, label="NR")
+
+        if (2, 2) in h_sur:
+            idx_nr_peak = np.argmax(np.abs(np.array(h22_nr)))
+            idx_sur_peak = np.argmax(np.abs(np.array(h22_sur)))
+            delta_phase = np.angle(h22_nr[idx_nr_peak]) - np.angle(
+                h22_sur[idx_sur_peak]
+            )
+            h22_sur_aligned = h22_sur * np.exp(1j * delta_phase)
+    except Exception:
+        pass
+
+    if (2, 2) in h_sur:
+        t_sur_full = np.array(h22_sur.sample_times)
+        re_sur = (
+            np.array(h22_sur_aligned.real())
+            if h22_sur_aligned is not None
+            else np.array(h22_sur.real())
+        )
+        mask = t_sur_full >= -0.25
+        ax.plot(
+            t_sur_full[mask],
+            re_sur[mask],
+            color="C1",
+            lw=1.2,
+            ls="--",
+            label="NRSur7dq4 (phase-aligned)",
+        )
+
+    ax.set_xlabel("t - t_peak [s]")
+    ax.set_ylabel("Re(h₂₂) [strain]")
+    ax.set_title("(2,2) real part — merger region")
+    ax.legend(fontsize=9)
+
+    ax = axes[2]
+    mode_labels = [f"({ell},{em:+d})" for (ell, em) in NR_MODES]
+    match_vals = [
+        results.get((ell, em), {}).get("match", float("nan")) for (ell, em) in NR_MODES
+    ]
+
+    colors = [
+        "C2"
+        if (not np.isnan(m) and m >= 0.99)
+        else "C3"
+        if (not np.isnan(m) and m >= 0.95)
+        else "C4"
+        if not np.isnan(m)
+        else "lightgray"
+        for m in match_vals
+    ]
+    bars = ax.bar(
+        mode_labels,
+        [m if not np.isnan(m) else 0 for m in match_vals],
+        color=colors,
+        edgecolor="k",
+        linewidth=0.8,
+    )
+    for bar, mv in zip(bars, match_vals):
+        if not np.isnan(mv):
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                bar.get_height() + 0.002,
+                f"{mv:.4f}",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+            )
+        else:
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                0.5,
+                "N/A",
+                ha="center",
+                va="center",
+                fontsize=8,
+                color="gray",
+            )
+
+    ax.axhline(0.99, color="C2", ls=":", lw=1, alpha=0.6, label="0.99")
+    ax.axhline(0.95, color="C3", ls=":", lw=1, alpha=0.6, label="0.95")
+    ax.set_ylim(0, 1.04)
+    ax.set_ylabel("Match")
+    ax.set_title(f"Per-mode match (NR vs NRSur7dq4, PSD: {psd_name})")
+    ax.legend(fontsize=8, loc="lower right")
+
+    plt.tight_layout()
+    safe_id = _safe_sim_id(sim_name)
+    fig_path = os.path.join(outdir, f"{safe_id}_mode_matches.png")
+    fig.savefig(fig_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"      Figure written: {fig_path}")
+
+
+def _print_table(results, sim_name):
+    w = 74
+    print(f"\n{'─'*w}")
+    print(f"  Mode-by-mode comparison: {sim_name} vs NRSur7dq4")
+    print(f"{'─'*w}")
+    print(
+        f"  {'Mode':<10} {'Match':>10}  {'ΔΦ/cycle [rad]':>16}  "
+        f"{'N_cycles':>10}  {'f_lower_mode':>14}"
+    )
+    print(f"{'─'*w}")
+    for (ell, em) in NR_MODES:
+        res = results.get((ell, em), {})
+        mm = res.get("match", float("nan"))
+        fl = res.get("f_lower_mode", float("nan"))
+        dp = res.get("phase_diff_per_cycle", float("nan"))
+        nc = res.get("n_cycles", float("nan"))
+        mm_str = f"{mm:.6f}" if not np.isnan(mm) else "    N/A  "
+        dp_str = f"{dp:.4f}" if not np.isnan(dp) else "           N/A"
+        nc_str = f"{nc:.1f}" if not np.isnan(nc) else "       N/A"
+        fl_str = f"{fl:.1f} Hz" if not np.isnan(fl) else "    N/A"
+        print(
+            f"  ({ell},{em:+d})      {mm_str:>10}  {dp_str:>16}  "
+            f"{nc_str:>10}  {fl_str:>14}"
+        )
+    print(f"{'─'*w}\n")

--- a/nrcatalogtools/surrogate.py
+++ b/nrcatalogtools/surrogate.py
@@ -1,0 +1,229 @@
+"""Surrogate waveform utilities for NR vs NRSur7dq4 comparisons.
+
+Handles loading the surrogate, calling it with NR-compatible parameters,
+and wrapping the output as physical-unit pycbc TimeSeries objects.
+
+NRSur7dq4 notes
+---------------
+* Precessing model — takes full 3-vector spins, returns all modes up to ell=4.
+* The ``ellMax`` parameter caps the output (max is 4); ``mode_list`` is not
+  supported for precessing models.
+* ``f_low`` controls waveform truncation only (start frequency); for NRSur7dq4
+  the recommended value is 0 (return the entire waveform).
+* ``f_ref`` sets the reference epoch at which the spins are defined; it is in
+  **cycles/M** (= M * f_GW where M is in seconds).  For the NR–surrogate
+  comparison the correct choice is ``f_ref = f_lower_NR * M_seconds``, which
+  aligns the surrogate spin epoch with the NR relaxation-time spin values.
+* ``dt`` argument is in dimensionless M units.
+* Output ``h[(ell,em)]`` is a complex numpy array representing the spin-weight
+  -2 spherical harmonic mode ``h_lm`` (same convention as SXS/RIT/MAYA NR
+  data: ``h_+ - i h_×`` decomposed as ``Σ h_lm Y_{-2,lm}``).
+* Time array ``t_sur`` is in dimensionless M units; ``t_sur[-1] ≈ +100 M``
+  is near merger (peak amplitude).
+
+Spin epoch conventions
+----------------------
+Two cases arise depending on whether the NR waveform starts before or after
+the surrogate's minimum training frequency (~0.0165 M·Ω_orbital):
+
+1. **NR shorter than surrogate** (``f_lower_NR > f_min_sur``):
+   Pass ``f_low=0`` (full waveform) and ``f_ref=f_lower_NR_dimless``.  The
+   surrogate backward-evolves the spins from the NR epoch to its start.
+
+2. **NR longer than surrogate** (``f_lower_NR < f_min_sur``):
+   The surrogate cannot extrapolate before its minimum frequency, so
+   ``f_ref`` is clipped to ``f_min_sur``.  For **aligned-spin or non-spinning
+   systems** the spin components are constant (no precession), so the metadata
+   spins remain valid regardless of epoch.  For **precessing systems** one
+   would need to extract the instantaneous spins from the NR dynamics at
+   ``f_min_sur`` — not yet implemented; a warning is emitted in that case.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from pycbc.types import TimeSeries
+
+from . import utils
+
+# Module-level surrogate singleton to avoid reloading the large model file.
+_nrsur7dq4 = None
+
+
+def load_nrsur7dq4():
+    """Load and cache the NRSur7dq4 surrogate model.
+
+    Returns
+    -------
+    gwsurrogate surrogate object
+    """
+    global _nrsur7dq4
+    if _nrsur7dq4 is None:
+        import gwsurrogate as gws
+
+        _nrsur7dq4 = gws.LoadSurrogate("NRSur7dq4")
+    return _nrsur7dq4
+
+
+# Modes available from NRSur7dq4 (ellMax ≤ 4; (5,5) is not available).
+SURROGATE_MODES = [(2, 2), (2, 1), (3, 3), (4, 4), (3, 2), (4, 3)]
+
+# Full set of NR modes to include in the comparison table.  Modes absent from
+# the surrogate (e.g. (5,5)) will appear with match=NaN in the output.
+NR_MODES = [(2, 2), (2, 1), (3, 3), (4, 4), (5, 5), (3, 2), (4, 3)]
+
+# Approximate surrogate minimum frequency in cycles/M (= M * f_GW in seconds).
+# Derived from the known NRSur7dq4 minimum M*Omega_orbital ≈ 0.0165:
+#   f_min_cycles_per_M = omega_min / pi ≈ 0.00525
+_SURROGATE_F_MIN_CYCLES_PER_M = 0.01717 / np.pi  # slightly above omega_0 ≈ 0.0165
+
+
+def generate_surrogate_modes(
+    params: dict,
+    total_mass: float,
+    distance: float = 1.0,
+    delta_t_seconds: float = 1.0 / 4096,
+) -> tuple[dict, float]:
+    """Call NRSur7dq4 and return physical-unit modes as a pycbc TimeSeries dict.
+
+    Parameters
+    ----------
+    params : dict
+        PyCBC-compatible binary parameter dict as returned by
+        ``CatalogBase.get_parameters()``.  Must contain:
+        ``mass1``, ``mass2``, ``spin1x/y/z``, ``spin2x/y/z``, ``f_lower``.
+    total_mass : float
+        Total binary mass in solar masses (sets the physical time/frequency
+        scale for the surrogate call).
+    distance : float, optional
+        Luminosity distance in Mpc for amplitude scaling (default 1).
+    delta_t_seconds : float, optional
+        Desired sample spacing in physical seconds (default 1/4096).
+
+    Returns
+    -------
+    tuple[dict, float]
+        ``({(ell, em): pycbc.types.TimeSeries}, f_lower_effective)`` —
+        complex mode time series in physical units with epoch at peak (2,2)
+        amplitude, plus the effective starting GW frequency in Hz.
+
+    Raises
+    ------
+    ValueError
+        If ``f_lower`` is not positive or the surrogate call fails.
+    """
+    q = params["mass1"] / params["mass2"]  # ≥ 1 by PyCBC convention
+    chiA = [params["spin1x"], params["spin1y"], params["spin1z"]]
+    chiB = [params["spin2x"], params["spin2y"], params["spin2z"]]
+    f_lower_hz = params["f_lower"]
+
+    if f_lower_hz <= 0:
+        raise ValueError(
+            f"f_lower = {f_lower_hz} Hz is not positive. "
+            "Cannot determine surrogate start frequency."
+        )
+
+    m_secs = utils.time_to_physical(total_mass)  # M * MTSUN_SI  [seconds]
+
+    # f_ref in cycles/M (= M * f_GW_hz, where M is in seconds).
+    f_ref_dimless = f_lower_hz * m_secs  # cycles/M
+    dt_dimless = delta_t_seconds / m_secs  # dimensionless time step
+
+    sur = load_nrsur7dq4()
+
+    chi1_perp = np.sqrt(chiA[0] ** 2 + chiA[1] ** 2)
+    chi2_perp = np.sqrt(chiB[0] ** 2 + chiB[1] ** 2)
+    is_precessing = (chi1_perp > 1e-4) or (chi2_perp > 1e-4)
+
+    try:
+        t_sur, h_sur, _ = sur(
+            q, chiA, chiB, ellMax=4, dt=dt_dimless, f_low=0, f_ref=f_ref_dimless
+        )
+    except Exception as exc:
+        err_str = str(exc)
+        if (
+            "too small" in err_str.lower()
+            or "omega_ref" in err_str
+            or "omega_0" in err_str
+        ):
+            import re
+
+            m_match = re.search(r"([0-9.]+)\s*=\s*omega_0", err_str)
+            if m_match:
+                omega_min = float(m_match.group(1)) * 1.01
+            else:
+                omega_min = 0.0170
+            f_ref_clipped = omega_min / np.pi
+
+            if is_precessing:
+                print(
+                    f"      WARNING: f_ref={f_ref_dimless:.5f} cycles/M is below "
+                    f"surrogate minimum; clipping to {f_ref_clipped:.5f}.  "
+                    "For precessing systems the NR spins should be extracted from "
+                    "NR dynamics at f_min_sur — using metadata spins instead "
+                    "(may introduce a spin-epoch error)."
+                )
+            t_sur, h_sur, _ = sur(
+                q, chiA, chiB, ellMax=4, dt=dt_dimless, f_low=0, f_ref=f_ref_clipped
+            )
+        else:
+            raise
+
+    amp_scale = utils.amp_to_physical(total_mass, distance)
+    t_physical = t_sur * m_secs
+
+    peak_idx = int(np.argmax(np.abs(h_sur[(2, 2)])))
+    peak_time_phys = t_physical[peak_idx]
+    epoch = t_physical[0] - peak_time_phys
+
+    phase22 = np.unwrap(np.angle(h_sur[(2, 2)]))
+    omega_gw_start = abs(phase22[1] - phase22[0]) / dt_dimless
+    f_lower_effective = omega_gw_start / (2.0 * np.pi) / m_secs
+
+    result = {}
+    for (ell, em) in SURROGATE_MODES:
+        if (ell, em) not in h_sur:
+            continue
+        h_phys = h_sur[(ell, em)] * amp_scale
+        result[(ell, em)] = TimeSeries(
+            h_phys.astype(np.complex128),
+            delta_t=delta_t_seconds,
+            epoch=epoch,
+        )
+
+    return result, f_lower_effective
+
+
+def check_surrogate_prior(
+    params: dict, q_max: float = 4.0, chi_max: float = 0.8
+) -> bool:
+    """Return True if the binary parameters fall within the NRSur7dq4 prior volume.
+
+    NRSur7dq4 is valid for:
+    - ``q = m1/m2 ∈ [1, 4]``
+    - ``|χ₁|, |χ₂| ≤ 0.8``
+    - Waveform length ≥ ~4350 M (not checked here — handled by the surrogate call).
+
+    Parameters
+    ----------
+    params : dict
+        PyCBC-compatible parameter dict.
+    q_max : float, optional
+        Maximum mass ratio (default 4).
+    chi_max : float, optional
+        Maximum spin magnitude (default 0.8).
+
+    Returns
+    -------
+    bool
+    """
+    q = params["mass1"] / params["mass2"]
+    if not (1.0 <= q <= q_max):
+        return False
+    chi1 = np.sqrt(
+        params["spin1x"] ** 2 + params["spin1y"] ** 2 + params["spin1z"] ** 2
+    )
+    chi2 = np.sqrt(
+        params["spin2x"] ** 2 + params["spin2y"] ** 2 + params["spin2z"] ** 2
+    )
+    return chi1 <= chi_max and chi2 <= chi_max

--- a/nrcatalogtools/waveform/__init__.py
+++ b/nrcatalogtools/waveform/__init__.py
@@ -9,6 +9,10 @@ from nrcatalogtools.waveform.modes import WaveformModes  # noqa: F401
 from nrcatalogtools.waveform.matching import (  # noqa: F401
     apply_wigner_rotation_to_mode_dict,
     interpolate_in_amp_phase,
+    load_psd,
+    compute_mode_match,
+    compute_phase_diff_per_cycle,
+    mode_f_lower,
 )
 from nrcatalogtools.waveform.units import ELL_MIN, ELL_MAX, _modal_dt  # noqa: F401
 
@@ -16,6 +20,10 @@ __all__ = [
     "WaveformModes",
     "apply_wigner_rotation_to_mode_dict",
     "interpolate_in_amp_phase",
+    "load_psd",
+    "compute_mode_match",
+    "compute_phase_diff_per_cycle",
+    "mode_f_lower",
     "ELL_MIN",
     "ELL_MAX",
     "_modal_dt",

--- a/nrcatalogtools/waveform/matching.py
+++ b/nrcatalogtools/waveform/matching.py
@@ -73,6 +73,211 @@ def apply_wigner_rotation_to_mode_dict(mode_dict, R, ell_max=4):
     return rotated
 
 
+def load_psd(
+    f_lower: float,
+    delta_t: float,
+    waveform_length_seconds: float,
+    psd_name: str = "aLIGOZeroDetHighPower",
+):
+    """Load a named analytic PSD sampled to match a waveform's frequency grid.
+
+    Parameters
+    ----------
+    f_lower : float
+        Low-frequency cutoff in Hz.
+    delta_t : float
+        Time step of the waveforms in seconds (sets the Nyquist limit).
+    waveform_length_seconds : float
+        Duration of the longest waveform in seconds (sets frequency resolution).
+    psd_name : str, optional
+        PyCBC analytic PSD name (default ``'aLIGOZeroDetHighPower'``).
+
+    Returns
+    -------
+    pycbc.types.FrequencySeries
+    """
+    from pycbc.psd import from_string
+
+    n_samples = int(waveform_length_seconds / delta_t)
+    n_fft = 1
+    while n_fft < n_samples:
+        n_fft <<= 1
+
+    delta_f = 1.0 / (n_fft * delta_t)
+    length_f = n_fft // 2 + 1
+
+    return from_string(psd_name, length_f, delta_f, low_freq_cutoff=f_lower)
+
+
+def compute_mode_match(
+    h_nr,
+    h_sur,
+    f_lower_mode: float,
+    psd_name: str = "aLIGOZeroDetHighPower",
+    f_upper=None,
+) -> float:
+    """Compute the noise-weighted match between one NR and one surrogate mode.
+
+    Both inputs should be the *real part* of the complex strain mode
+    (h₊ component), sampled at the same ``delta_t``.  The function pads to
+    the next power-of-two, builds a PSD at the matching frequency resolution,
+    and calls ``pycbc.filter.match()``.
+
+    Parameters
+    ----------
+    h_nr : pycbc.types.TimeSeries
+        Real-valued NR mode time series.
+    h_sur : pycbc.types.TimeSeries
+        Real-valued surrogate mode time series.
+    f_lower_mode : float
+        Low-frequency cutoff for this mode in Hz.
+        Use ``f_lower * |m| / 2`` (GW frequency scales as |m| × f_orbital).
+    psd_name : str, optional
+        PyCBC analytic PSD name (default ``'aLIGOZeroDetHighPower'``).
+    f_upper : float or None, optional
+        Upper frequency cutoff in Hz (default: Nyquist).
+
+    Returns
+    -------
+    float
+        Match in [0, 1], or ``float('nan')`` if either waveform has zero norm.
+    """
+    from pycbc.filter import match as pycbc_match
+    from pycbc.psd import from_string
+
+    if (
+        float(np.max(np.abs(np.array(h_nr)))) < 1e-50
+        or float(np.max(np.abs(np.array(h_sur)))) < 1e-50
+    ):
+        return float("nan")
+
+    t_start = max(float(h_nr.start_time), float(h_sur.start_time))
+    t_end = min(float(h_nr.end_time), float(h_sur.end_time))
+
+    if t_end <= t_start:
+        return float("nan")
+
+    h_nr_sliced = h_nr.time_slice(t_start, t_end)
+    h_sur_sliced = h_sur.time_slice(t_start, t_end)
+
+    from pycbc.waveform.utils import taper_timeseries
+
+    h1_tapered = taper_timeseries(h_nr_sliced, tapermethod="startend", return_lal=False)
+    h2_tapered = taper_timeseries(
+        h_sur_sliced, tapermethod="startend", return_lal=False
+    )
+
+    raw_len = max(len(h1_tapered), len(h2_tapered))
+    n_fft = 1
+    while n_fft < raw_len:
+        n_fft <<= 1
+
+    h1 = h1_tapered.copy()
+    h1.resize(n_fft)
+    h2 = h2_tapered.copy()
+    h2.resize(n_fft)
+
+    delta_f = 1.0 / (n_fft * h1.delta_t)
+    length_f = n_fft // 2 + 1
+    psd = from_string(psd_name, length_f, delta_f, low_freq_cutoff=f_lower_mode)
+
+    mm, _ = pycbc_match(
+        h1,
+        h2,
+        psd=psd,
+        low_frequency_cutoff=f_lower_mode,
+        high_frequency_cutoff=f_upper,
+    )
+    return float(mm)
+
+
+def compute_phase_diff_per_cycle(h_nr, h_sur) -> tuple:
+    """Compute accumulated phase difference per GW cycle over the common window.
+
+    Both inputs are the *complex* mode time series (h_lm = h+ - i h×).
+    The two waveforms are trimmed to their shared time window (both should have
+    epoch set so t=0 is at peak amplitude), then the total accumulated phase of
+    each is computed from the unwrapped angle.
+
+    The metric returned is::
+
+        phase_diff_per_cycle = |ΔΦ_NR - ΔΦ_sur| / N_cycles_NR   [rad / cycle]
+
+    where ``ΔΦ = |φ(t_end) - φ(t_start)|`` is the total phase evolved and
+    ``N_cycles_NR = ΔΦ_NR / (2π)``.
+
+    Parameters
+    ----------
+    h_nr : pycbc.types.TimeSeries
+        Complex NR mode time series.
+    h_sur : pycbc.types.TimeSeries
+        Complex surrogate mode time series.
+
+    Returns
+    -------
+    tuple[float, float]
+        ``(phase_diff_per_cycle, n_cycles_nr)``.
+        Returns ``(nan, nan)`` if either waveform has zero norm or the common
+        window contains fewer than 2 samples.
+    """
+    arr_nr = np.array(h_nr)
+    arr_sur = np.array(h_sur)
+
+    if float(np.max(np.abs(arr_nr))) < 1e-50 or float(np.max(np.abs(arr_sur))) < 1e-50:
+        return float("nan"), float("nan")
+
+    dt = float(h_nr.delta_t)
+    t_start = max(float(h_nr.start_time), float(h_sur.start_time))
+    t_end = min(float(h_nr.end_time), float(h_sur.end_time))
+
+    if t_end <= t_start:
+        return float("nan"), float("nan")
+
+    i_nr_s = max(0, int(round((t_start - float(h_nr.start_time)) / dt)))
+    i_nr_e = min(len(arr_nr), int(round((t_end - float(h_nr.start_time)) / dt)) + 1)
+    i_sur_s = max(0, int(round((t_start - float(h_sur.start_time)) / dt)))
+    i_sur_e = min(len(arr_sur), int(round((t_end - float(h_sur.start_time)) / dt)) + 1)
+
+    n = min(i_nr_e - i_nr_s, i_sur_e - i_sur_s)
+    if n < 2:
+        return float("nan"), float("nan")
+
+    phi_nr = np.unwrap(np.angle(arr_nr[i_nr_s : i_nr_s + n]))
+    phi_sur = np.unwrap(np.angle(arr_sur[i_sur_s : i_sur_s + n]))
+
+    delta_phi_nr = abs(phi_nr[-1] - phi_nr[0])
+    delta_phi_sur = abs(phi_sur[-1] - phi_sur[0])
+
+    n_cycles_nr = delta_phi_nr / (2.0 * np.pi)
+    if n_cycles_nr < 0.5:
+        return float("nan"), float("nan")
+
+    phase_diff_per_cycle = abs(delta_phi_nr - delta_phi_sur) / n_cycles_nr
+    return float(phase_diff_per_cycle), float(n_cycles_nr)
+
+
+def mode_f_lower(f_lower: float, em: int) -> float:
+    """Return the GW frequency cutoff for mode (ell, m).
+
+    GW frequency for the (ell, |m|) mode is approximately |m| times the
+    orbital frequency: ``f_gw ≈ |m| * f_orbital = |m| * f_lower / 2``
+    (since the (2,2) mode has ``f_gw = 2 * f_orbital``).
+
+    Parameters
+    ----------
+    f_lower : float
+        Orbital reference frequency in Hz (= half the (2,2) GW frequency).
+    em : int
+        Azimuthal mode number m.
+
+    Returns
+    -------
+    float
+        Mode-specific GW frequency cutoff in Hz.
+    """
+    return f_lower * abs(em) / 2.0 if em != 0 else f_lower
+
+
 def interpolate_in_amp_phase(obj, new_time, k=3, kind=None):
     """Interpolate in amplitude and phase using a variety of methods.
 

--- a/nrcatalogtools/waveform/matching.py
+++ b/nrcatalogtools/waveform/matching.py
@@ -6,7 +6,22 @@ be unit-tested and used independently of the class.
 
 import numpy as np
 import spherical
+from pycbc.types import TimeSeries as pycbc_TimeSeries
 from sxs import TimeSeries as sxs_TimeSeries
+
+try:
+    from pycbc.waveform.utils import taper_timeseries as _pycbc_taper
+
+    def _taper(ts):
+        return _pycbc_taper(ts, tapermethod="startend", return_lal=False)
+
+except ImportError:
+    from scipy.signal.windows import tukey as _tukey
+
+    def _taper(ts):
+        win = _tukey(len(ts), alpha=0.1).astype(np.float64)
+        data = np.array(ts) * win
+        return pycbc_TimeSeries(data, delta_t=ts.delta_t, epoch=ts.start_time)
 
 
 def apply_wigner_rotation_to_mode_dict(mode_dict, R, ell_max=4):
@@ -160,12 +175,8 @@ def compute_mode_match(
     h_nr_sliced = h_nr.time_slice(t_start, t_end)
     h_sur_sliced = h_sur.time_slice(t_start, t_end)
 
-    from pycbc.waveform.utils import taper_timeseries
-
-    h1_tapered = taper_timeseries(h_nr_sliced, tapermethod="startend", return_lal=False)
-    h2_tapered = taper_timeseries(
-        h_sur_sliced, tapermethod="startend", return_lal=False
-    )
+    h1_tapered = _taper(h_nr_sliced)
+    h2_tapered = _taper(h_sur_sliced)
 
     raw_len = max(len(h1_tapered), len(h2_tapered))
     n_fft = 1

--- a/test/test_catalog_helpers.py
+++ b/test/test_catalog_helpers.py
@@ -1,0 +1,176 @@
+"""Unit tests for load_catalog() and filter_by_surrogate_prior() in nrcatalogtools."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import nrcatalogtools as nrcat
+
+
+# ── load_catalog ──────────────────────────────────────────────────────────────
+
+
+def test_load_catalog_sxs_calls_sxs_load():
+    mock_cat = MagicMock()
+    with patch.object(nrcat.SXSCatalog, "load", return_value=mock_cat) as mock_load:
+        result = nrcat.load_catalog("SXS")
+    mock_load.assert_called_once_with(download=False)
+    assert result is mock_cat
+
+
+def test_load_catalog_rit_calls_rit_load():
+    mock_cat = MagicMock()
+    with patch.object(nrcat.RITCatalog, "load", return_value=mock_cat) as mock_load:
+        result = nrcat.load_catalog("RIT")
+    mock_load.assert_called_once_with()
+    assert result is mock_cat
+
+
+def test_load_catalog_maya_calls_maya_load():
+    mock_cat = MagicMock()
+    with patch.object(nrcat.MayaCatalog, "load", return_value=mock_cat) as mock_load:
+        result = nrcat.load_catalog("MAYA")
+    mock_load.assert_called_once_with()
+    assert result is mock_cat
+
+
+@pytest.mark.parametrize("name", ["sxs", "Sxs", "SXS", "sXs"])
+def test_load_catalog_sxs_case_insensitive(name):
+    with patch.object(nrcat.SXSCatalog, "load", return_value=MagicMock()) as mock_load:
+        nrcat.load_catalog(name)
+    mock_load.assert_called_once()
+
+
+@pytest.mark.parametrize("name", ["rit", "Rit", "RIT"])
+def test_load_catalog_rit_case_insensitive(name):
+    with patch.object(nrcat.RITCatalog, "load", return_value=MagicMock()) as mock_load:
+        nrcat.load_catalog(name)
+    mock_load.assert_called_once()
+
+
+def test_load_catalog_unknown_raises_value_error():
+    with pytest.raises(ValueError, match="Unknown catalog"):
+        nrcat.load_catalog("LIGO")
+
+
+def test_load_catalog_unknown_message_lists_supported():
+    with pytest.raises(ValueError, match="SXS.*RIT.*MAYA"):
+        nrcat.load_catalog("ETDetector")
+
+
+def test_load_catalog_kwargs_forwarded_to_rit():
+    with patch.object(nrcat.RITCatalog, "load", return_value=MagicMock()) as mock_load:
+        nrcat.load_catalog("RIT", verbosity=2)
+    mock_load.assert_called_once_with(verbosity=2)
+
+
+# ── filter_by_surrogate_prior ─────────────────────────────────────────────────
+
+
+def _aligned_params(q=1.5, chi1z=0.3, chi2z=0.0):
+    """Minimal PyCBC params dict within the NRSur7dq4 prior."""
+    return {
+        "mass1": q * 20.0,
+        "mass2": 20.0,
+        "spin1x": 0.0,
+        "spin1y": 0.0,
+        "spin1z": chi1z,
+        "spin2x": 0.0,
+        "spin2y": 0.0,
+        "spin2z": chi2z,
+        "f_lower": 20.0,
+    }
+
+
+def _make_catalog(sim_names, params_per_sim=None):
+    """Build a mock catalog returning fixed params for each sim."""
+    mock = MagicMock()
+    mock.simulations_list = sim_names
+    if params_per_sim is None:
+        params_per_sim = {n: _aligned_params() for n in sim_names}
+    mock.get_parameters.side_effect = lambda name, **kw: params_per_sim[name]
+    return mock
+
+
+def test_filter_all_pass():
+    cat = _make_catalog(["SIM1", "SIM2", "SIM3"])
+    result = nrcat.filter_by_surrogate_prior(cat)
+    assert result == ["SIM1", "SIM2", "SIM3"]
+
+
+def test_filter_some_fail_high_q():
+    params = {
+        "SIM1": _aligned_params(q=1.5),
+        "SIM2": _aligned_params(q=5.0),  # outside prior
+        "SIM3": _aligned_params(q=2.0),
+    }
+    cat = _make_catalog(list(params), params)
+    result = nrcat.filter_by_surrogate_prior(cat)
+    assert result == ["SIM1", "SIM3"]
+
+
+def test_filter_some_fail_high_spin():
+    params = {
+        "SIM1": _aligned_params(chi1z=0.3),
+        "SIM2": _aligned_params(chi1z=0.9),  # outside prior
+    }
+    cat = _make_catalog(list(params), params)
+    result = nrcat.filter_by_surrogate_prior(cat)
+    assert result == ["SIM1"]
+
+
+def test_filter_metadata_error_silently_skipped():
+    """Simulations that raise on get_parameters should be skipped, not crash."""
+    mock = MagicMock()
+    mock.simulations_list = ["GOOD", "BAD", "ALSO_GOOD"]
+
+    def _get_params(name, **kw):
+        if name == "BAD":
+            raise KeyError("metadata missing")
+        return _aligned_params()
+
+    mock.get_parameters.side_effect = _get_params
+    result = nrcat.filter_by_surrogate_prior(mock)
+    assert result == ["GOOD", "ALSO_GOOD"]
+
+
+def test_filter_empty_catalog():
+    cat = _make_catalog([])
+    assert nrcat.filter_by_surrogate_prior(cat) == []
+
+
+def test_filter_respects_custom_q_max():
+    params = {
+        "SIM1": _aligned_params(q=3.0),
+        "SIM2": _aligned_params(q=4.0),
+    }
+    cat = _make_catalog(list(params), params)
+    result = nrcat.filter_by_surrogate_prior(cat, q_max=3.5)
+    assert result == ["SIM1"]
+
+
+def test_filter_respects_custom_chi_max():
+    params = {
+        "SIM1": _aligned_params(chi1z=0.5),
+        "SIM2": _aligned_params(chi1z=0.7),
+    }
+    cat = _make_catalog(list(params), params)
+    result = nrcat.filter_by_surrogate_prior(cat, chi_max=0.6)
+    assert result == ["SIM1"]
+
+
+def test_filter_verbose_prints_progress(capsys):
+    """verbose=True should print at least one progress line."""
+    cat = _make_catalog([f"SIM{i}" for i in range(60)])
+    nrcat.filter_by_surrogate_prior(cat, verbose=True)
+    out = capsys.readouterr().out
+    assert "Checking" in out
+
+
+def test_filter_uses_total_mass_kwarg():
+    """total_mass should be forwarded to get_parameters."""
+    cat = _make_catalog(["SIM1"])
+    nrcat.filter_by_surrogate_prior(cat, total_mass=80.0)
+    cat.get_parameters.assert_called_once_with("SIM1", total_mass=80.0)

--- a/test/test_surrogate.py
+++ b/test/test_surrogate.py
@@ -1,0 +1,225 @@
+"""Unit tests for nrcatalogtools.surrogate."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from pycbc.types import TimeSeries
+
+from nrcatalogtools.surrogate import (
+    NR_MODES,
+    SURROGATE_MODES,
+    check_surrogate_prior,
+    generate_surrogate_modes,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _params(
+    q=1.0,
+    chi1x=0.0,
+    chi1y=0.0,
+    chi1z=0.0,
+    chi2x=0.0,
+    chi2y=0.0,
+    chi2z=0.0,
+    f_lower=20.0,
+):
+    return {
+        "mass1": q * 20.0,
+        "mass2": 20.0,
+        "spin1x": chi1x,
+        "spin1y": chi1y,
+        "spin1z": chi1z,
+        "spin2x": chi2x,
+        "spin2y": chi2y,
+        "spin2z": chi2z,
+        "f_lower": f_lower,
+    }
+
+
+def _mock_surrogate(n=4096):
+    """Callable mock that mimics gwsurrogate NRSur7dq4.
+
+    Returns (t_sur, h_sur, None) where h22 has a Gaussian-envelope peak near
+    t=+10 M (dimensionless) so generate_surrogate_modes can find peak_idx.
+    """
+    t = np.linspace(-100, 100, n)
+    envelope = np.exp(-0.5 * ((t - 10) / 5) ** 2)
+    h_sur = {
+        (2, 2): (envelope * np.exp(2j * t)).astype(np.complex128),
+        (2, 1): (0.1 * envelope * np.exp(1j * t)).astype(np.complex128),
+        (3, 3): (0.05 * envelope * np.exp(3j * t)).astype(np.complex128),
+        (4, 4): (0.02 * envelope * np.exp(4j * t)).astype(np.complex128),
+        (3, 2): (0.03 * envelope * np.exp(2j * t)).astype(np.complex128),
+        (4, 3): (0.01 * envelope * np.exp(3j * t)).astype(np.complex128),
+    }
+    mock = MagicMock()
+    mock.return_value = (t, h_sur, None)
+    return mock
+
+
+# ── check_surrogate_prior ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "q, chi1z, chi2z, expected",
+    [
+        (1.0, 0.0, 0.0, True),  # equal mass, non-spinning
+        (4.0, 0.8, 0.8, True),  # at both limits simultaneously
+        (4.0, 0.0, 0.0, True),  # at q limit
+        (1.0, 0.8, 0.0, True),  # at chi1 limit
+        (4.01, 0.0, 0.0, False),  # q just above limit
+        (0.5, 0.0, 0.0, False),  # q < 1 (inverted convention)
+        (1.0, 0.81, 0.0, False),  # chi1 above limit
+        (1.0, 0.0, 0.81, False),  # chi2 above limit
+        (2.5, 0.5, -0.6, True),  # both within limits, mixed signs
+    ],
+)
+def test_check_surrogate_prior_aligned(q, chi1z, chi2z, expected):
+    # Use == rather than 'is': the final return expression yields numpy.bool_
+    # for the True branch (from chi1 <= chi_max and chi2 <= chi_max).
+    assert check_surrogate_prior(_params(q=q, chi1z=chi1z, chi2z=chi2z)) == expected
+
+
+def test_check_surrogate_prior_3d_spin_magnitude_exceeds_limit():
+    """Total 3D spin magnitude > chi_max should fail even if each component is small."""
+    # |chi1| = sqrt(0.5^2 + 0.5^2 + 0.5^2) ≈ 0.866 > 0.8
+    params = _params(chi1x=0.5, chi1y=0.5, chi1z=0.5)
+    assert not check_surrogate_prior(params)
+
+
+def test_check_surrogate_prior_custom_q_limit():
+    params = _params(q=3.0)
+    assert not check_surrogate_prior(params, q_max=2.0)
+    assert check_surrogate_prior(params, q_max=4.0)
+
+
+def test_check_surrogate_prior_custom_chi_limit():
+    params = _params(chi1z=0.5)
+    assert not check_surrogate_prior(params, chi_max=0.4)
+    assert check_surrogate_prior(params, chi_max=0.6)
+
+
+# ── constants ─────────────────────────────────────────────────────────────────
+
+
+def test_nr_modes_includes_55_not_in_surrogate():
+    """(5,5) is NR-only — must appear in NR_MODES but not SURROGATE_MODES."""
+    assert (5, 5) in NR_MODES
+    assert (5, 5) not in SURROGATE_MODES
+
+
+def test_surrogate_modes_are_subset_of_nr_modes():
+    for mode in SURROGATE_MODES:
+        assert mode in NR_MODES, f"{mode} in SURROGATE_MODES but not in NR_MODES"
+
+
+def test_surrogate_modes_all_within_ell4():
+    """NRSur7dq4 supports at most ell=4."""
+    for ell, _ in SURROGATE_MODES:
+        assert ell <= 4
+
+
+def test_modes_are_positive_m_only():
+    """Both mode lists store only positive m (convention for mode labelling)."""
+    for ell, em in NR_MODES:
+        assert em > 0, f"Expected positive m, got ({ell}, {em})"
+    for ell, em in SURROGATE_MODES:
+        assert em > 0, f"Expected positive m, got ({ell}, {em})"
+
+
+# ── load_nrsur7dq4 ────────────────────────────────────────────────────────────
+
+
+def test_load_nrsur7dq4_caches_singleton():
+    """gwsurrogate.LoadSurrogate must be called exactly once regardless of call count."""
+    import nrcatalogtools.surrogate as _sur_mod
+
+    mock_sur = MagicMock()
+    mock_gws = MagicMock()
+    mock_gws.LoadSurrogate.return_value = mock_sur
+
+    with patch.object(_sur_mod, "_nrsur7dq4", None):
+        with patch.dict("sys.modules", {"gwsurrogate": mock_gws}):
+            r1 = _sur_mod.load_nrsur7dq4()
+            r2 = _sur_mod.load_nrsur7dq4()
+
+    mock_gws.LoadSurrogate.assert_called_once_with("NRSur7dq4")
+    assert r1 is r2
+
+
+# ── generate_surrogate_modes ──────────────────────────────────────────────────
+
+
+def test_generate_surrogate_modes_returns_timeseries_per_mode():
+    """Result should contain one complex TimeSeries per SURROGATE_MODE key."""
+    params = _params(q=2.0, chi1z=0.3, chi2z=-0.2)
+
+    with patch(
+        "nrcatalogtools.surrogate.load_nrsur7dq4", return_value=_mock_surrogate()
+    ):
+        result, f_lower_eff = generate_surrogate_modes(
+            params, total_mass=60.0, distance=1.0, delta_t_seconds=1.0 / 4096
+        )
+
+    assert set(result.keys()) == set(SURROGATE_MODES)
+    for mode, ts in result.items():
+        assert isinstance(ts, TimeSeries), f"mode {mode} is not a TimeSeries"
+        assert ts.dtype == np.complex128, f"mode {mode} dtype is {ts.dtype}"
+    assert f_lower_eff > 0.0
+
+
+def test_generate_surrogate_modes_epoch_at_h22_peak():
+    """Epoch should be negative (t=0 at peak, waveform starts in the past)."""
+    params = _params(q=1.5)
+
+    with patch(
+        "nrcatalogtools.surrogate.load_nrsur7dq4", return_value=_mock_surrogate()
+    ):
+        result, _ = generate_surrogate_modes(params, total_mass=60.0)
+
+    h22 = result[(2, 2)]
+    # Peak at t=0 means start_time < 0
+    assert float(h22.start_time) < 0.0
+
+
+def test_generate_surrogate_modes_negative_f_lower_raises():
+    params = _params(f_lower=-5.0)
+    with patch("nrcatalogtools.surrogate.load_nrsur7dq4", return_value=MagicMock()):
+        with pytest.raises(ValueError, match="not positive"):
+            generate_surrogate_modes(params, total_mass=60.0)
+
+
+def test_generate_surrogate_modes_clips_f_ref_on_omega_error():
+    """If surrogate raises omega_ref error, f_ref should be clipped and retried."""
+    params = _params(
+        q=1.0, f_lower=5.0
+    )  # low f_lower → f_ref likely below surrogate min
+
+    # First call raises the omega error; second call succeeds
+    mock_sur = _mock_surrogate()
+    omega_error = RuntimeError(
+        "omega_ref = 0.003 is too small; omega_0 = 0.0170 = omega_0"
+    )
+    call_count = {"n": 0}
+
+    def _side_effect(q, chiA, chiB, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise omega_error
+        return mock_sur.return_value
+
+    mock_sur.side_effect = _side_effect
+
+    with patch("nrcatalogtools.surrogate.load_nrsur7dq4", return_value=mock_sur):
+        result, _ = generate_surrogate_modes(params, total_mass=60.0)
+
+    assert (
+        call_count["n"] == 2
+    ), "Expected exactly two surrogate calls (initial + retry)"
+    assert set(result.keys()) == set(SURROGATE_MODES)

--- a/test/test_waveform_matching.py
+++ b/test/test_waveform_matching.py
@@ -1,0 +1,191 @@
+"""Unit tests for the per-mode match helpers in nrcatalogtools.waveform.matching."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pycbc.types import FrequencySeries, TimeSeries
+
+from nrcatalogtools.waveform.matching import (
+    compute_mode_match,
+    compute_phase_diff_per_cycle,
+    load_psd,
+    mode_f_lower,
+)
+
+# ── shared fixtures ───────────────────────────────────────────────────────────
+
+_DELTA_T = 1.0 / 4096
+_DURATION = 2.0  # seconds
+_N = int(_DURATION / _DELTA_T)  # 8192 samples
+_T = np.arange(_N) * _DELTA_T
+_F0 = 50.0  # Hz — well above f_lower=20 Hz, well below Nyquist
+
+
+def _real_ts(freq=_F0, epoch=0.0):
+    """Real-valued sinusoidal TimeSeries."""
+    data = np.sin(2 * np.pi * freq * _T).astype(np.float64)
+    return TimeSeries(data, delta_t=_DELTA_T, epoch=epoch)
+
+
+def _complex_ts(freq=_F0, epoch=0.0):
+    """Complex exponential TimeSeries (constant amplitude, linear phase)."""
+    data = np.exp(2j * np.pi * freq * _T).astype(np.complex128)
+    return TimeSeries(data, delta_t=_DELTA_T, epoch=epoch)
+
+
+# ── mode_f_lower ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "f_lower, em, expected",
+    [
+        (20.0, 2, 20.0),  # (2,2): f_gw = f_orbital * |m| / 2 * 2 = f_lower
+        (20.0, 3, 30.0),  # (3,3): f_gw = 20 * 3 / 2 = 30 Hz
+        (20.0, 4, 40.0),  # (4,4): f_gw = 20 * 4 / 2 = 40 Hz
+        (20.0, 1, 10.0),  # (2,1): f_gw = 20 * 1 / 2 = 10 Hz
+        (20.0, -2, 20.0),  # negative m: same as |m|
+        (20.0, -3, 30.0),
+        (10.0, 2, 10.0),  # different f_lower
+    ],
+)
+def test_mode_f_lower(f_lower, em, expected):
+    assert mode_f_lower(f_lower, em) == pytest.approx(expected)
+
+
+def test_mode_f_lower_zero_m_returns_f_lower():
+    assert mode_f_lower(20.0, 0) == 20.0
+
+
+# ── load_psd ──────────────────────────────────────────────────────────────────
+
+
+def test_load_psd_returns_frequency_series():
+    psd = load_psd(f_lower=20.0, delta_t=_DELTA_T, waveform_length_seconds=_DURATION)
+    assert isinstance(psd, FrequencySeries)
+
+
+def test_load_psd_length_and_delta_f():
+    """n_fft is next power-of-two >= n_samples; delta_f = 1 / (n_fft * delta_t)."""
+    psd = load_psd(f_lower=20.0, delta_t=_DELTA_T, waveform_length_seconds=_DURATION)
+    # n_samples = 8192, n_fft = 8192 (already power of 2)
+    # delta_f = 1 / (8192 / 4096) = 0.5 Hz
+    assert abs(psd.delta_f - 0.5) < 1e-9
+    assert len(psd) == 8192 // 2 + 1
+
+
+def test_load_psd_non_power_of_two_duration():
+    """Non-power-of-two n_samples should round up to next power of two."""
+    # 1.5 s at 4096 Hz → 6144 samples → n_fft = 8192
+    psd = load_psd(f_lower=20.0, delta_t=_DELTA_T, waveform_length_seconds=1.5)
+    assert abs(psd.delta_f - 0.5) < 1e-9  # same n_fft = 8192
+
+
+# ── compute_mode_match ────────────────────────────────────────────────────────
+
+
+def test_compute_mode_match_identical_waveforms():
+    """Match of a signal with itself must be 1."""
+    h = _real_ts()
+    mm = compute_mode_match(h, h.copy(), f_lower_mode=20.0)
+    assert abs(mm - 1.0) < 1e-5
+
+
+def test_compute_mode_match_zero_nr_waveform():
+    """Zero-norm first argument should return NaN."""
+    h_zero = TimeSeries(np.zeros(_N, dtype=np.float64), delta_t=_DELTA_T)
+    h = _real_ts()
+    mm = compute_mode_match(h_zero, h, f_lower_mode=20.0)
+    assert np.isnan(mm)
+
+
+def test_compute_mode_match_zero_sur_waveform():
+    """Zero-norm second argument should return NaN."""
+    h = _real_ts()
+    h_zero = TimeSeries(np.zeros(_N, dtype=np.float64), delta_t=_DELTA_T)
+    mm = compute_mode_match(h, h_zero, f_lower_mode=20.0)
+    assert np.isnan(mm)
+
+
+def test_compute_mode_match_non_overlapping_time_windows():
+    """Waveforms that don't share a time window should return NaN."""
+    h1 = _real_ts(epoch=0.0)  # t ∈ [0, 2)
+    h2 = _real_ts(epoch=3.0)  # t ∈ [3, 5) — no overlap
+    mm = compute_mode_match(h1, h2, f_lower_mode=20.0)
+    assert np.isnan(mm)
+
+
+def test_compute_mode_match_in_range():
+    """Match between any two non-zero real waveforms must lie in [0, 1]."""
+    h1 = _real_ts(freq=50.0)
+    h2 = _real_ts(freq=60.0)
+    mm = compute_mode_match(h1, h2, f_lower_mode=20.0)
+    assert not np.isnan(mm)
+    assert 0.0 <= mm <= 1.0
+
+
+# ── compute_phase_diff_per_cycle ─────────────────────────────────────────────
+
+
+def test_phase_diff_identical_waveforms_is_zero():
+    """Phase difference between a signal and itself must be zero."""
+    h = _complex_ts()
+    diff, n_cyc = compute_phase_diff_per_cycle(h, h.copy())
+    assert not np.isnan(diff)
+    assert abs(diff) < 1e-8
+    assert n_cyc > 0
+
+
+def test_phase_diff_returns_expected_cycle_count():
+    """n_cycles_nr should equal roughly f0 * duration."""
+    h = _complex_ts(freq=_F0)
+    diff, n_cyc = compute_phase_diff_per_cycle(h, h.copy())
+    expected_cycles = _F0 * _DURATION
+    assert abs(n_cyc - expected_cycles) < 1.0  # within 1 cycle
+
+
+def test_phase_diff_zero_norm_first_arg():
+    h_zero = TimeSeries(np.zeros(_N, dtype=np.complex128), delta_t=_DELTA_T)
+    h = _complex_ts()
+    diff, n_cyc = compute_phase_diff_per_cycle(h_zero, h)
+    assert np.isnan(diff) and np.isnan(n_cyc)
+
+
+def test_phase_diff_zero_norm_second_arg():
+    h = _complex_ts()
+    h_zero = TimeSeries(np.zeros(_N, dtype=np.complex128), delta_t=_DELTA_T)
+    diff, n_cyc = compute_phase_diff_per_cycle(h, h_zero)
+    assert np.isnan(diff) and np.isnan(n_cyc)
+
+
+def test_phase_diff_non_overlapping_time_windows():
+    h1 = _complex_ts(epoch=0.0)
+    h2 = _complex_ts(epoch=3.0)
+    diff, n_cyc = compute_phase_diff_per_cycle(h1, h2)
+    assert np.isnan(diff) and np.isnan(n_cyc)
+
+
+def test_phase_diff_too_few_cycles_returns_nan():
+    """Waveform with < 0.5 accumulated GW cycles should return (nan, nan)."""
+    # 20 samples at 4096 Hz ≈ 4.9 ms; at 50 Hz → ~0.24 cycles < 0.5
+    n_short = 20
+    h_short = TimeSeries(
+        np.exp(2j * np.pi * _F0 * np.arange(n_short) * _DELTA_T).astype(np.complex128),
+        delta_t=_DELTA_T,
+    )
+    diff, n_cyc = compute_phase_diff_per_cycle(h_short, h_short.copy())
+    assert np.isnan(diff) and np.isnan(n_cyc)
+
+
+def test_phase_diff_known_phase_offset():
+    """A surrogate with a constant extra phase offset should accumulate zero phase diff
+    (phase_diff_per_cycle measures *accumulated* phase difference, not absolute offset).
+    """
+    h_nr = _complex_ts(freq=_F0)
+    # shift by a constant phase — the *rate* of phase evolution is unchanged
+    phase_offset = np.pi / 4
+    data_sur = np.exp(2j * np.pi * _F0 * _T + 1j * phase_offset).astype(np.complex128)
+    h_sur = TimeSeries(data_sur, delta_t=_DELTA_T, epoch=0.0)
+
+    diff, _ = compute_phase_diff_per_cycle(h_nr, h_sur)
+    assert abs(diff) < 1e-6


### PR DESCRIPTION
- Add nrcatalogtools/surrogate.py (load_nrsur7dq4, generate_surrogate_modes,
check_surrogate_prior, NR_MODES/SURROGATE_MODES constants) and
nrcatalogtools/comparisons.py (compare_sim_vs_surrogate with its CSV/figure
output helpers) extracted from the project scripts.

- Extend nrcatalogtools/waveform/matching.py with the four per-mode match
helpers (load_psd, compute_mode_match, compute_phase_diff_per_cycle,
mode_f_lower) that were previously script-local.

- Add load_catalog() and filter_by_surrogate_prior() to the top-level
nrcatalogtools/__init__.py so callers no longer need to dispatch to catalog
subclasses by name or import from scripts.