### PR TITLE
Improve waveform comparison tools

### DIFF
--- a/docs/api/waveform.md
+++ b/docs/api/waveform.md
@@ -29,6 +29,8 @@ utilities for loading, rotating, and matching NR waveforms.
         - f_lower_at_relaxation
         - trim_to_relaxation_time
         - get_parameters
+        - match_sphere_averaged
+        - match_sphere_averaged_bms_maximized
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ MayaCatalog.load()
 | `get_td_waveform(M, D, iota, phi, dt)` | Sky-averaged h₊+ih× summed over all modes |
 | `trim_to_relaxation_time(M)` | (2,2) mode starting at relaxation epoch |
 | `rotated(R)` | Wigner D-matrix rotation of all modes (inherited + overridden) |
-| `match_sphere_averaged(other, psd, f_lower)` | Mismatch minimized over t_c, φ_c, R∈SO(3) via Nelder-Mead |
+| `match_sphere_averaged(other, psd, f_lower)` | Mismatch minimized over t_c, φ_c, R∈SO(3) via differential evolution |
 | `match_sphere_averaged_bms_maximized(...)` | Same + BMS supertranslation optimization via spin-weighted Gaunt coefficients (`scri`) |
 
 ---

--- a/docs/waveform.md
+++ b/docs/waveform.md
@@ -160,11 +160,22 @@ Useful for rotating surrogate model outputs into the NR frame for direct compari
 
 ### `match_sphere_averaged(other, psd, f_lower, delta_t, ...)`
 
-Sky-averaged mismatch minimized over $t_c$, $\phi_c$, and $R \in SO(3)$:
+This method calculates the match (noise-weighted overlap) between two waveforms, integrated over the entire sphere of possible observer directions (sky-averaged) and maximized over coordinate time shift $t_c$, coalescence phase $\phi_c$, and active/passive $SO(3)$ rotation $R$.
 
-$$\mathcal{M} = 1 - \max_{t_c,\, \phi_c,\, R \in SO(3)} \frac{\langle h_1 | h_2 \rangle}{\sqrt{\langle h_1 | h_1 \rangle \langle h_2 | h_2 \rangle}}$$
+#### Spherical Integration & Mode-by-Mode Equivalence
+The overlap between the full multidimensional strain fields $h_1(t, \Omega)$ and $h_2(t, \Omega)$ over the sphere $S^2$ is defined as:
+$$\mathcal{O}_{\text{sphere}}(h_1, h_2) = \frac{\int_{S^2} \langle h_1(t, \Omega) \mid h_2(t, \Omega) \rangle_t \, d\Omega}{\sqrt{\left[ \int_{S^2} \langle h_1(t, \Omega) \mid h_1(t, \Omega) \rangle_t \, d\Omega \right] \left[ \int_{S^2} \langle h_2(t, \Omega) \mid h_2(t, \Omega) \rangle_t \, d\Omega \right]}}$$
 
-<!-- Mismatch = 1 - max over (time shift, phase shift, SO(3) rotation) of normalized inner product -->
+By expanding the strain fields in spin-weighted spherical harmonics ${}^{-2}Y_{\ell m}(\theta, \phi)$ and invoking their orthonormality:
+$$\int_{S^2} {}^{-2}Y_{\ell m}^*(\Omega) \, {}^{-2}Y_{\ell' m'}(\Omega) \, d\Omega = \delta_{\ell \ell'} \, \delta_{m m'}$$
+all cross-terms between different modes decouple and vanish. The integrated overlap simplifies to the sum of the mode-by-mode overlaps:
+$$\int_{S^2} \langle h_1(t, \Omega) \mid h_2(t, \Omega) \rangle_t \, d\Omega = \sum_{\ell, m} \langle h_{1, \ell m} \mid h_{2, \ell m} \rangle_t$$
+
+#### Extrinsic Optimization
+To align the coordinate frames, the second waveform is transformed via:
+$$h_{2, \ell m}^{\text{rot, shifted}}(t) = e^{-i m \phi_c} \sum_{m'=-\ell}^{\ell} h_{2, \ell m'}(t - t_c) \, D^{\ell}_{m' m}(R)$$
+where $D^\ell_{m'm}(R)$ is the Wigner D-matrix. The returned mismatch $\mathcal{M}$ is defined as:
+$$\mathcal{M} = 1 - \max_{t_c,\, \phi_c,\, R \in SO(3)} \left[ \frac{\sum_{\ell, m} \langle h_{1, \ell m} \mid h_{2, \ell m}^{\text{rot, shifted}}(t_c, \phi_c, R) \rangle_t}{\sqrt{\left( \sum_{\ell, m} \langle h_{1, \ell m} \mid h_{1, \ell m} \rangle_t \right) \left( \sum_{\ell, m} \langle h_{2, \ell m} \mid h_{2, \ell m} \rangle_t \right)}} \right]$$
 
 ```python
 mismatch = wfm_a.match_sphere_averaged(
@@ -177,13 +188,21 @@ mismatch = wfm_a.match_sphere_averaged(
 
 ### `match_sphere_averaged_bms_maximized(other, psd, f_lower, j_max, ...)`
 
-Extended version that additionally optimizes over BMS supertranslation coefficients:
+This extended method performs the optimization over the infinite-dimensional **BMS supertranslation** group at null infinity $\mathcal{I}^+$ in addition to the standard rigid rotations and shifts. 
 
-$$h'_{\ell m}(u) = h_{\ell m}(u) - \sum_{j,k,p,q} \alpha_{jk} \, \mathcal{G}^{\ell m}_{jk,pq} \, \dot{h}_{pq}(u)$$
+Supertranslations correspond to direction-dependent retarded-time shifts:
+$$u' = u - \alpha(\theta, \phi)$$
+where the supertranslation field $\alpha(\theta, \phi)$ is decomposed into scalar spherical harmonics:
+$$\alpha(\theta, \phi) = \sum_{j=0}^{j_{\text{max}}} \sum_{k=-j}^{j} \alpha_{jk} \, Y_{jk}(\theta, \phi)$$
+For small supertranslations, the waveform modes undergo first-order mixing:
+$$h'_{\ell m}(u) = h_{\ell m}(u) - \sum_{j=0}^{j_{\text{max}}} \sum_{k=-j}^{j} \sum_{p, q} \alpha_{jk} \, \mathcal{G}^{\ell m}_{jk,pq} \, \dot{h}_{pq}(u)$$
+where $\mathcal{G}^{\ell m}_{jk,pq}$ are the spin-weighted Gaunt coefficients:
+$$\mathcal{G}^{\ell m}_{jk,pq} = \int_{S^2} {}^{-2}Y_{\ell m}^*(\Omega) \, Y_{jk}(\Omega) \, {}^{-2}Y_{pq}(\Omega) \, d\Omega$$
 
-<!-- Modified strain = original strain minus sum over BMS supertranslation modes weighted by Gaunt coefficients -->
+This method optimizes $t_c$, $\phi_c$, $R \in SO(3)$, and the supertranslation coefficients $\alpha_{jk}$ (where $j=1$ shifts the coordinate origin to correct for center-of-mass drift, and $j \ge 2$ modes correct for proper supertranslations) using a Nelder-Mead simplex solver to find the global minimum mismatch.
 
-Requires the `scri` package for spin-weighted Gaunt coefficients.
+> [!NOTE]
+> The `scri` package is required to compute the spin-weighted Gaunt coupling coefficients $\mathcal{G}^{\ell m}_{jk,pq}$.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,7 @@ plugins:
         python:
           paths: [.]
           options:
-            docstring_style: google
+            docstring_style: numpy
             show_source: true
             show_root_heading: true
             show_root_full_path: false

--- a/nrcatalogtools/comparisons.py
+++ b/nrcatalogtools/comparisons.py
@@ -114,10 +114,22 @@ def compare_sim_vs_surrogate(
         )
 
     # 3. Generate surrogate modes
-    print(f"[3/6] Generating NRSur7dq4 modes (M={total_mass} M☉, D={DISTANCE} Mpc)...")
-    h_sur, f_lower_sur = generate_surrogate_modes(
-        params, total_mass=total_mass, distance=DISTANCE, delta_t_seconds=delta_t
+    print(
+        f"[3/6] Generating NRSur7dq4 modes (M={total_mass:.1f} M☉, D={DISTANCE:.1f} Mpc)..."
     )
+    try:
+        h_sur, f_lower_sur = generate_surrogate_modes(
+            params,
+            total_mass,
+            DISTANCE,
+            delta_t_seconds=delta_t,
+            sim_name=sim_name,
+            catalog=cat,
+            nr_wfm=wfm,
+        )
+    except Exception as exc:
+        print(f"      Failed to generate surrogate: {exc}")
+        raise
     print(f"      Generated {len(h_sur)} surrogate modes.")
     if f_lower_sur > f_lower * 1.05:
         print(
@@ -194,7 +206,9 @@ def compare_sim_vs_surrogate(
         )
 
     if rotate:
-        print("[5b] Computing SO(3)-rotation-optimized match (Nelder-Mead)...")
+        print(
+            "[5b] Computing SO(3)-rotation-optimized match (differential evolution)..."
+        )
         try:
             from .waveform.matching import load_psd
 

--- a/nrcatalogtools/comparisons.py
+++ b/nrcatalogtools/comparisons.py
@@ -150,6 +150,9 @@ def compare_sim_vs_surrogate(
                 "phase_diff_per_cycle": float("nan"),
                 "n_cycles": float("nan"),
                 "match_rotated": None,
+                "R_alpha": None,
+                "R_beta": None,
+                "R_gamma": None,
             }
             continue
 
@@ -163,6 +166,9 @@ def compare_sim_vs_surrogate(
                 "phase_diff_per_cycle": float("nan"),
                 "n_cycles": float("nan"),
                 "match_rotated": None,
+                "R_alpha": None,
+                "R_beta": None,
+                "R_gamma": None,
             }
             continue
 
@@ -176,6 +182,9 @@ def compare_sim_vs_surrogate(
             "phase_diff_per_cycle": dphase,
             "n_cycles": n_cycles,
             "match_rotated": None,
+            "R_alpha": None,
+            "R_beta": None,
+            "R_gamma": None,
         }
         flag = "" if np.isnan(mm) else f"{mm:.6f}"
         dp_str = "N/A" if np.isnan(dphase) else f"{dphase:.4f} rad"
@@ -194,17 +203,28 @@ def compare_sim_vs_surrogate(
             psd_rot = load_psd(
                 f_lower_match, delta_t, max(dur_nr, dur_sur) * 1.1, psd_name=psd_name
             )
-            mm_rot = wfm.match_sphere_averaged(
+
+            mm_rot, R_opt = wfm.match_sphere_averaged(
                 h_sur,
                 psd=psd_rot,
                 f_lower=f_lower_match,
                 delta_t=delta_t,
+                return_rotation=True,
+                total_mass=total_mass,
+                distance=DISTANCE,
             )
             print(f"      SO(3)-optimized match = {mm_rot:.6f}")
+            alpha, beta, gamma = R_opt.to_euler_angles
             for key in results:
                 results[key]["match_rotated"] = mm_rot
+                results[key]["R_alpha"] = alpha
+                results[key]["R_beta"] = beta
+                results[key]["R_gamma"] = gamma
         except Exception as exc:
             print(f"      SO(3)-optimized match failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
 
     # 6. Output
     print(f"[6/6] Writing outputs (results to {outdir}/, figures to {figsdir}/)...")
@@ -248,6 +268,9 @@ def _write_csv(results, sim_name, catalog_name, total_mass, params, outdir):
                 "match_rotated": res["match_rotated"]
                 if res["match_rotated"] is not None
                 else "",
+                "R_alpha": res["R_alpha"] if res["R_alpha"] is not None else "",
+                "R_beta": res["R_beta"] if res["R_beta"] is not None else "",
+                "R_gamma": res["R_gamma"] if res["R_gamma"] is not None else "",
             }
         )
     fieldnames = list(rows[0].keys())

--- a/nrcatalogtools/comparisons.py
+++ b/nrcatalogtools/comparisons.py
@@ -113,7 +113,18 @@ def compare_sim_vs_surrogate(
             "Proceeding, but surrogate extrapolation may be unreliable."
         )
 
-    # 3. Generate surrogate modes
+    chi1_perp = np.sqrt(params["spin1x"] ** 2 + params["spin1y"] ** 2)
+    chi2_perp = np.sqrt(params["spin2x"] ** 2 + params["spin2y"] ** 2)
+    is_precessing = (chi1_perp > 1e-4) or (chi2_perp > 1e-4)
+    if is_precessing and not rotate:
+        print("      Precessing system: enabling SO(3)-optimized match automatically.")
+        rotate = True
+
+    # 3. Generate surrogate modes.
+    # For precessing SXS binaries the surrogate spins are epoch-aligned to the
+    # NR dynamics at the surrogate's training-window start (Phase 2), regardless
+    # of the rotate flag.  The rotate flag only controls whether an additional
+    # SO(3) frame optimisation is performed after the per-mode matches.
     print(
         f"[3/6] Generating NRSur7dq4 modes (M={total_mass:.1f} M☉, D={DISTANCE:.1f} Mpc)..."
     )

--- a/nrcatalogtools/lvc.py
+++ b/nrcatalogtools/lvc.py
@@ -695,7 +695,7 @@ def transform_spins_nr_to_lal(
     ---------
     nrSpin1, nrSpin2 : list
              A list of the components of the spins of the objects.
-    nhat, ln_hat : list
+    n_hat, ln_hat : list
              A list of the components of the unit vectors of the objects,
              against which the components of the spins are specified.
     Returns
@@ -755,7 +755,7 @@ def get_nr_to_lal_rotation_angles(
                   The inclination angle.
     phi_ref : float
              The orbital phase at reference time.
-    Fref, t_ref : float, optional
+    f_ref, t_ref : float, optional
                  The reference orbital frequency or time
 
     sim_metadata : dict

--- a/nrcatalogtools/surrogate.py
+++ b/nrcatalogtools/surrogate.py
@@ -11,9 +11,10 @@ NRSur7dq4 notes
 * ``f_low`` controls waveform truncation only (start frequency); for NRSur7dq4
   the recommended value is 0 (return the entire waveform).
 * ``f_ref`` sets the reference epoch at which the spins are defined; it is in
-  **cycles/M** (= M * f_GW where M is in seconds).  For the NR–surrogate
-  comparison the correct choice is ``f_ref = f_lower_NR * M_seconds``, which
-  aligns the surrogate spin epoch with the NR relaxation-time spin values.
+  **cycles/M** (= M * f_GW where M is in seconds).  For aligned-spin or
+  non-spinning systems ``f_ref = f_lower_NR * M_seconds`` is sufficient.  For
+  precessing SXS systems Phase 2 extracts the instantaneous spins from
+  ``Horizons.h5`` at the epoch corresponding to the chosen ``f_ref``.
 * ``dt`` argument is in dimensionless M units.
 * Output ``h[(ell,em)]`` is a complex numpy array representing the spin-weight
   -2 spherical harmonic mode ``h_lm`` (same convention as SXS/RIT/MAYA NR
@@ -34,9 +35,9 @@ the surrogate's minimum training frequency (~0.0165 M·Ω_orbital):
    The surrogate cannot extrapolate before its minimum frequency, so
    ``f_ref`` is clipped to ``f_min_sur``.  For **aligned-spin or non-spinning
    systems** the spin components are constant (no precession), so the metadata
-   spins remain valid regardless of epoch.  For **precessing systems** one
-   would need to extract the instantaneous spins from the NR dynamics at
-   ``f_min_sur`` — not yet implemented; a warning is emitted in that case.
+   spins remain valid regardless of epoch.  For **precessing SXS systems**
+   Phase 2 automatically re-extracts the spin vectors from ``Horizons.h5`` at
+   the clipped epoch so that the spin-epoch is always physically consistent.
 """
 
 from __future__ import annotations
@@ -78,11 +79,139 @@ SURROGATE_MODES = [(ell, em) for ell, em in NR_MODES if ell <= 4]
 _SURROGATE_F_MIN_CYCLES_PER_M = 0.01717 / np.pi  # slightly above omega_0 ≈ 0.0165
 
 
+def _epoch_align_spins(
+    sim_obj,
+    target_t_before_merger: float | None = None,
+    f_ref_target: float | None = None,
+) -> tuple[list, list, float]:
+    """Extract frame-aligned spin vectors for a precessing SXS simulation.
+
+    Loads the Horizons.h5 data from ``sim_obj``, evaluates the orbital frame
+    (separation direction n̂ and angular-momentum direction L̂) at the
+    requested epoch, and rotates the inertial-frame spin vectors into the
+    coprecessing frame expected by NRSur7dq4.
+
+    Exactly one of the following must be supplied to specify the epoch:
+
+    * ``target_t_before_merger`` — time before the waveform peak (in M).
+      The epoch is ``t_peak − target_t_before_merger``, clamped to the
+      available horizon-data range.
+    * ``f_ref_target`` — target GW frequency in cycles/M.  The function
+      finds the earliest NR time at which the (2,2) mode frequency first
+      reaches or exceeds this value.
+
+    Parameters
+    ----------
+    sim_obj : sxs.Simulation_v3
+        Loaded SXS simulation object (from ``sxs.load``).
+    target_t_before_merger : float, optional
+        Seconds before merger (in M units) to use as the epoch.
+    f_ref_target : float, optional
+        Target GW frequency in cycles/M for the epoch.
+
+    Returns
+    -------
+    tuple[list, list, float]
+        ``(chiA, chiB, f_ref_dimless)`` — spin 3-vectors in the
+        coprecessing frame at the chosen epoch, plus the corresponding
+        GW frequency in cycles/M.
+    """
+    if (target_t_before_merger is None) == (f_ref_target is None):
+        raise ValueError(
+            "Exactly one of target_t_before_merger or f_ref_target must be given."
+        )
+
+    strain = sim_obj.strain
+    h = sim_obj.horizons
+    t_h = h.A.time  # (N,) numpy array, absolute NR coordinate time in M
+
+    # -- Determine reference time in NR coordinates -------------------------
+    if f_ref_target is not None:
+        # Find the first sample where f_GW >= f_ref_target.
+        h22_data = strain.data[:, strain.index(2, 2)]
+        phase22 = np.unwrap(np.angle(h22_data))
+        omega22_ts = np.gradient(phase22, strain.t)
+        f_gw_ts = np.abs(omega22_ts) / (2.0 * np.pi)
+        mask = f_gw_ts >= f_ref_target
+        if not np.any(mask):
+            raise ValueError(
+                f"NR waveform never reaches f_ref={f_ref_target:.5f} cycles/M."
+            )
+        t_target = strain.t[int(np.argmax(mask))]
+    else:
+        t_target = strain.max_norm_time() - target_t_before_merger
+
+    # Clamp to the available horizon time range.
+    t_ref = float(np.clip(t_target, t_h[0], t_h[-1]))
+    idx_h = int(np.argmin(np.abs(t_h - t_ref)))
+    idx_h = int(np.clip(idx_h, 1, len(t_h) - 2))
+
+    # -- Extract spin vectors (plain numpy, shape (3,)) ---------------------
+    chi_A = h.A.chi_inertial.ndarray[idx_h]
+    chi_B = h.B.chi_inertial.ndarray[idx_h]
+
+    # -- Compute orbital frame at this epoch --------------------------------
+    # n̂: unit vector from BH B (lighter) to BH A (heavier)
+    r_A = h.A.coord_center_inertial.ndarray[idx_h]
+    r_B = h.B.coord_center_inertial.ndarray[idx_h]
+    r_sep = r_A - r_B
+    nhat = r_sep / np.linalg.norm(r_sep)
+
+    # L̂: orbital angular-momentum direction from r × ṙ (central difference)
+    r_sep_plus = (
+        h.A.coord_center_inertial.ndarray[idx_h + 1]
+        - h.B.coord_center_inertial.ndarray[idx_h + 1]
+    )
+    r_sep_minus = (
+        h.A.coord_center_inertial.ndarray[idx_h - 1]
+        - h.B.coord_center_inertial.ndarray[idx_h - 1]
+    )
+    dt_h = t_h[idx_h + 1] - t_h[idx_h - 1]
+    v_sep = (r_sep_plus - r_sep_minus) / dt_h
+    L_vec = np.cross(r_sep, v_sep)
+    Lhat = L_vec / np.linalg.norm(L_vec)
+
+    # -- Build rotation matrix: inertial → coprecessing frame ---------------
+    # Coprecessing frame convention for NRSur7dq4:
+    #   x̂_cop = n̂  (separation direction)
+    #   ẑ_cop = L̂  (orbital angular momentum)
+    #   ŷ_cop = L̂ × n̂  (right-handed completion)
+    lambdahat = np.cross(Lhat, nhat)
+    lambdahat /= np.linalg.norm(lambdahat)
+    R = np.array([nhat, lambdahat, Lhat])  # rows = new basis vectors in inertial frame
+
+    chiA_rot = list(R @ chi_A)
+    chiB_rot = list(R @ chi_B)
+
+    # -- GW frequency at the chosen epoch -----------------------------------
+    t_wfm = strain.t
+    idx_wfm = int(np.argmin(np.abs(t_wfm - t_h[idx_h])))
+    idx_wfm = int(np.clip(idx_wfm, 1, len(t_wfm) - 2))
+    h22_data = strain.data[:, strain.index(2, 2)]
+    phase22 = np.unwrap(np.angle(h22_data))
+    dt_wfm = t_wfm[idx_wfm + 1] - t_wfm[idx_wfm - 1]
+    omega22 = (phase22[idx_wfm + 1] - phase22[idx_wfm - 1]) / dt_wfm
+    f_gw = float(np.abs(omega22) / (2.0 * np.pi))
+
+    t_actual = t_h[idx_h]
+    print(
+        f"      [Phase 2] epoch t={t_actual:.1f}M  f_ref={f_gw:.5f} cycles/M\n"
+        f"               chi_A=[{chiA_rot[0]:.4f},{chiA_rot[1]:.4f},{chiA_rot[2]:.4f}]"
+        f"  |χ_A|={np.linalg.norm(chi_A):.4f}\n"
+        f"               chi_B=[{chiB_rot[0]:.4f},{chiB_rot[1]:.4f},{chiB_rot[2]:.4f}]"
+        f"  |χ_B|={np.linalg.norm(chi_B):.4f}"
+    )
+    return chiA_rot, chiB_rot, f_gw, R
+
+
 def generate_surrogate_modes(
     params: dict,
     total_mass: float,
     distance: float = 1.0,
     delta_t_seconds: float = 1.0 / 4096,
+    sim_name: str | None = None,
+    catalog=None,
+    nr_wfm=None,
 ) -> tuple[dict, float]:
     """Call NRSur7dq4 and return physical-unit modes as a pycbc TimeSeries dict.
 
@@ -99,6 +228,12 @@ def generate_surrogate_modes(
         Luminosity distance in Mpc for amplitude scaling (default 1).
     delta_t_seconds : float, optional
         Desired sample spacing in physical seconds (default 1/4096).
+    sim_name : str, optional
+        Simulation name, used for epoch-aligned spin extraction on precessing SXS runs.
+    catalog : CatalogBase, optional
+        Catalog instance; enables Phase 2 epoch alignment when the catalog is SXS.
+    nr_wfm : WaveformModes, optional
+        Unused; kept for API compatibility.
 
     Returns
     -------
@@ -135,6 +270,36 @@ def generate_surrogate_modes(
     chi2_perp = np.sqrt(chiB[0] ** 2 + chiB[1] ** 2)
     is_precessing = (chi1_perp > 1e-4) or (chi2_perp > 1e-4)
 
+    # --- Phase 2: Proper epoch alignment for precessing SXS binaries ---
+    # For aligned-spin/non-spinning systems the spins are constant, so
+    # the metadata values are valid at any epoch.  For precessing systems
+    # we must extract the instantaneous spin vectors from the NR dynamics
+    # at a common epoch and rotate them into the surrogate's coprecessing
+    # reference frame before calling NRSur7dq4.
+    _phase2_sim_obj = None
+    if (
+        is_precessing
+        and catalog is not None
+        and getattr(catalog, "CATALOG_TYPE", None) == "SXS"
+        and sim_name
+    ):
+        try:
+            import sxs as _sxs
+
+            _phase2_sim_obj = _sxs.load(sim_name, auto_supersede=True, download=False)
+            chiA, chiB, f_ref_dimless, _phase2_R = _epoch_align_spins(
+                _phase2_sim_obj, target_t_before_merger=4500.0
+            )
+        except Exception as _exc:
+            import traceback
+
+            traceback.print_exc()
+            print(
+                f"      [Phase 2 Warning] Epoch alignment failed ({_exc}); "
+                "falling back to metadata spins."
+            )
+    # -----------------------------------------------------------------------
+
     try:
         t_sur, h_sur, _ = sur(
             q, chiA, chiB, ellMax=4, dt=dt_dimless, f_low=0, f_ref=f_ref_dimless
@@ -155,7 +320,23 @@ def generate_surrogate_modes(
                 omega_min = 0.0170
             f_ref_clipped = omega_min / np.pi
 
-            if is_precessing:
+            if is_precessing and _phase2_sim_obj is not None:
+                # The epoch implied by f_ref_clipped differs from the one we
+                # used above — re-extract spin vectors at the correct NR epoch.
+                try:
+                    chiA, chiB, f_ref_clipped, _phase2_R = _epoch_align_spins(
+                        _phase2_sim_obj, f_ref_target=f_ref_clipped
+                    )
+                    print(
+                        f"      [Phase 2] f_ref clipped to {f_ref_clipped:.5f} cycles/M; "
+                        "re-extracted epoch-aligned spins."
+                    )
+                except Exception as _exc2:
+                    print(
+                        f"      [Phase 2 Warning] Re-alignment at clipped f_ref failed "
+                        f"({_exc2}); keeping previously aligned spins."
+                    )
+            elif is_precessing:
                 print(
                     f"      WARNING: f_ref={f_ref_dimless:.5f} cycles/M is below "
                     f"surrogate minimum; clipping to {f_ref_clipped:.5f}.  "

--- a/nrcatalogtools/surrogate.py
+++ b/nrcatalogtools/surrogate.py
@@ -146,42 +146,55 @@ def _epoch_align_spins(
     idx_h = int(np.argmin(np.abs(t_h - t_ref)))
     idx_h = int(np.clip(idx_h, 1, len(t_h) - 2))
 
-    # -- Extract spin vectors (plain numpy, shape (3,)) ---------------------
-    chi_A = h.A.chi_inertial.ndarray[idx_h]
-    chi_B = h.B.chi_inertial.ndarray[idx_h]
+    # -- Identify heavier / lighter body ------------------------------------
+    # gwsurrogate convention (lalsimulation-compatible):
+    #   χ_x = χ · n̂,        n̂ = lighter→heavier (body2→body1)
+    #   χ_y = χ · (L̂ × n̂)
+    #   χ_z = χ · L̂
+    # The SXS labeling (A, B) does not guarantee A is heavier, so we check.
+    mA = float(h.A.mass[idx_h])
+    mB = float(h.B.mass[idx_h])
+    if mA >= mB:
+        chi_primary = h.A.chi_inertial.ndarray[idx_h]  # heavier
+        chi_secondary = h.B.chi_inertial.ndarray[idx_h]  # lighter
+        r_primary = h.A.coord_center_inertial.ndarray[idx_h]
+        r_secondary = h.B.coord_center_inertial.ndarray[idx_h]
+        r_primary_p = h.A.coord_center_inertial.ndarray[idx_h + 1]
+        r_secondary_p = h.B.coord_center_inertial.ndarray[idx_h + 1]
+        r_primary_m = h.A.coord_center_inertial.ndarray[idx_h - 1]
+        r_secondary_m = h.B.coord_center_inertial.ndarray[idx_h - 1]
+    else:
+        chi_primary = h.B.chi_inertial.ndarray[idx_h]  # heavier
+        chi_secondary = h.A.chi_inertial.ndarray[idx_h]  # lighter
+        r_primary = h.B.coord_center_inertial.ndarray[idx_h]
+        r_secondary = h.A.coord_center_inertial.ndarray[idx_h]
+        r_primary_p = h.B.coord_center_inertial.ndarray[idx_h + 1]
+        r_secondary_p = h.A.coord_center_inertial.ndarray[idx_h + 1]
+        r_primary_m = h.B.coord_center_inertial.ndarray[idx_h - 1]
+        r_secondary_m = h.A.coord_center_inertial.ndarray[idx_h - 1]
 
     # -- Compute orbital frame at this epoch --------------------------------
-    # n̂: unit vector from BH B (lighter) to BH A (heavier)
-    r_A = h.A.coord_center_inertial.ndarray[idx_h]
-    r_B = h.B.coord_center_inertial.ndarray[idx_h]
-    r_sep = r_A - r_B
+    # n̂: unit vector from lighter (body2/secondary) to heavier (body1/primary)
+    r_sep = r_primary - r_secondary
     nhat = r_sep / np.linalg.norm(r_sep)
 
     # L̂: orbital angular-momentum direction from r × ṙ (central difference)
-    r_sep_plus = (
-        h.A.coord_center_inertial.ndarray[idx_h + 1]
-        - h.B.coord_center_inertial.ndarray[idx_h + 1]
-    )
-    r_sep_minus = (
-        h.A.coord_center_inertial.ndarray[idx_h - 1]
-        - h.B.coord_center_inertial.ndarray[idx_h - 1]
-    )
+    r_sep_plus = r_primary_p - r_secondary_p
+    r_sep_minus = r_primary_m - r_secondary_m
     dt_h = t_h[idx_h + 1] - t_h[idx_h - 1]
     v_sep = (r_sep_plus - r_sep_minus) / dt_h
     L_vec = np.cross(r_sep, v_sep)
     Lhat = L_vec / np.linalg.norm(L_vec)
 
     # -- Build rotation matrix: inertial → coprecessing frame ---------------
-    # Coprecessing frame convention for NRSur7dq4:
-    #   x̂_cop = n̂  (separation direction)
-    #   ẑ_cop = L̂  (orbital angular momentum)
-    #   ŷ_cop = L̂ × n̂  (right-handed completion)
+    # Right-handed frame (n̂, L̂×n̂, L̂): x̂=n̂, ŷ=L̂×n̂, ẑ=L̂.
+    # Verified against gwsurrogate DynamicsSurrogate convention.
     lambdahat = np.cross(Lhat, nhat)
     lambdahat /= np.linalg.norm(lambdahat)
     R = np.array([nhat, lambdahat, Lhat])  # rows = new basis vectors in inertial frame
 
-    chiA_rot = list(R @ chi_A)
-    chiB_rot = list(R @ chi_B)
+    chiA_rot = list(R @ chi_primary)  # heavier body — returned as chiA
+    chiB_rot = list(R @ chi_secondary)  # lighter body — returned as chiB
 
     # -- GW frequency at the chosen epoch -----------------------------------
     t_wfm = strain.t
@@ -195,11 +208,12 @@ def _epoch_align_spins(
 
     t_actual = t_h[idx_h]
     print(
-        f"      [Phase 2] epoch t={t_actual:.1f}M  f_ref={f_gw:.5f} cycles/M\n"
-        f"               chi_A=[{chiA_rot[0]:.4f},{chiA_rot[1]:.4f},{chiA_rot[2]:.4f}]"
-        f"  |χ_A|={np.linalg.norm(chi_A):.4f}\n"
-        f"               chi_B=[{chiB_rot[0]:.4f},{chiB_rot[1]:.4f},{chiB_rot[2]:.4f}]"
-        f"  |χ_B|={np.linalg.norm(chi_B):.4f}"
+        f"      [Phase 2] epoch t={t_actual:.1f}M  f_ref={f_gw:.5f} cycles/M"
+        f"  (primary={'A' if mA >= mB else 'B'})\n"
+        f"               chi_primary=[{chiA_rot[0]:.4f},{chiA_rot[1]:.4f},{chiA_rot[2]:.4f}]"
+        f"  |χ|={np.linalg.norm(chi_primary):.4f}\n"
+        f"               chi_secondary=[{chiB_rot[0]:.4f},{chiB_rot[1]:.4f},{chiB_rot[2]:.4f}]"
+        f"  |χ|={np.linalg.norm(chi_secondary):.4f}"
     )
     return chiA_rot, chiB_rot, f_gw, R
 
@@ -266,6 +280,15 @@ def generate_surrogate_modes(
 
     sur = load_nrsur7dq4()
 
+    # Query the surrogate's training window start from its internal metadata so
+    # that epoch-aligned spin extraction targets the correct NR time regardless
+    # of which surrogate model is loaded.  Fall back to a conservative value if
+    # the attribute is absent (e.g. a future surrogate with a different layout).
+    try:
+        _sur_t_start_M = abs(sur._sur_dimless.t_0)
+    except AttributeError:
+        _sur_t_start_M = 4500.0
+
     chi1_perp = np.sqrt(chiA[0] ** 2 + chiA[1] ** 2)
     chi2_perp = np.sqrt(chiB[0] ** 2 + chiB[1] ** 2)
     is_precessing = (chi1_perp > 1e-4) or (chi2_perp > 1e-4)
@@ -288,7 +311,7 @@ def generate_surrogate_modes(
 
             _phase2_sim_obj = _sxs.load(sim_name, auto_supersede=True, download=False)
             chiA, chiB, f_ref_dimless, _phase2_R = _epoch_align_spins(
-                _phase2_sim_obj, target_t_before_merger=4500.0
+                _phase2_sim_obj, target_t_before_merger=_sur_t_start_M
             )
         except Exception as _exc:
             import traceback

--- a/nrcatalogtools/surrogate.py
+++ b/nrcatalogtools/surrogate.py
@@ -65,12 +65,12 @@ def load_nrsur7dq4():
     return _nrsur7dq4
 
 
-# Modes available from NRSur7dq4 (ellMax ≤ 4; (5,5) is not available).
-SURROGATE_MODES = [(2, 2), (2, 1), (3, 3), (4, 4), (3, 2), (4, 3)]
-
 # Full set of NR modes to include in the comparison table.  Modes absent from
 # the surrogate (e.g. (5,5)) will appear with match=NaN in the output.
 NR_MODES = [(2, 2), (2, 1), (3, 3), (4, 4), (5, 5), (3, 2), (4, 3)]
+
+# Positive-m modes produced by NRSur7dq4 (ellMax=4); subset of NR_MODES.
+SURROGATE_MODES = [(ell, em) for ell, em in NR_MODES if ell <= 4]
 
 # Approximate surrogate minimum frequency in cycles/M (= M * f_GW in seconds).
 # Derived from the known NRSur7dq4 minimum M*Omega_orbital ≈ 0.0165:
@@ -227,3 +227,54 @@ def check_surrogate_prior(
         params["spin2x"] ** 2 + params["spin2y"] ** 2 + params["spin2z"] ** 2
     )
     return chi1 <= chi_max and chi2 <= chi_max
+
+
+def surrogate_dict_to_waveform_modes(h_sur_dict: dict, ell_max: int = 4):
+    """Wrap a dictionary of pycbc mode TimeSeries into a WaveformModes object.
+
+    Parameters
+    ----------
+    h_sur_dict : dict
+        Dict mapping (ell, em) -> pycbc.TimeSeries.
+    ell_max : int, optional
+        Maximum ell value to support (default 4).
+
+    Returns
+    -------
+    WaveformModes
+    """
+    from nrcatalogtools.waveform.modes import WaveformModes
+
+    if not h_sur_dict:
+        raise ValueError("h_sur_dict is empty")
+
+    class SurrogateWaveformModes(WaveformModes):
+        def __init__(self, h_dict, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._h_dict = h_dict
+
+        def get_mode(self, ell, em, **kwargs):
+            return self._h_dict[(ell, em)]
+
+    # Extract time array from any mode
+    any_mode = next(iter(h_sur_dict.values()))
+    time_array = np.array(any_mode.sample_times)
+
+    # Calculate number of modes for ell_min=2
+    num_modes = (ell_max + 1) ** 2 - 4
+    data = np.zeros((len(time_array), num_modes), dtype=complex)
+
+    wfm = SurrogateWaveformModes(
+        h_sur_dict, data, time=time_array, ell_min=2, ell_max=ell_max
+    )
+
+    for (ell, m), ts in h_sur_dict.items():
+        if ell > ell_max or ell < 2:
+            continue
+        try:
+            idx = wfm.index(ell, m)
+            wfm.data[:, idx] = ts.data
+        except ValueError:
+            pass  # Ignore modes that are not within the index range
+
+    return wfm

--- a/nrcatalogtools/waveform/__init__.py
+++ b/nrcatalogtools/waveform/__init__.py
@@ -1,8 +1,6 @@
 """nrcatalogtools.waveform sub-package.
 
-Re-exports the complete public API that was previously in the monolithic
-``waveform.py`` module so that all existing import paths continue to work
-without modification.
+Exports the complete public API for the waveform module.
 """
 
 from nrcatalogtools.waveform.modes import WaveformModes  # noqa: F401

--- a/nrcatalogtools/waveform/matching.py
+++ b/nrcatalogtools/waveform/matching.py
@@ -19,7 +19,7 @@ except ImportError:
     from scipy.signal.windows import tukey as _tukey
 
     def _taper(ts):
-        win = _tukey(len(ts), alpha=0.1).astype(np.float64)
+        win = _tukey(len(ts), alpha=0.2).astype(np.float64)
         data = np.array(ts) * win
         return pycbc_TimeSeries(data, delta_t=ts.delta_t, epoch=ts.start_time)
 
@@ -263,6 +263,12 @@ def compute_phase_diff_per_cycle(h_nr, h_sur) -> tuple:
     if n_cycles_nr < 0.5:
         return float("nan"), float("nan")
 
+    # |ΔΦ_NR − ΔΦ_sur| measures the difference in total accumulated phase
+    # (i.e. cycle-count error) over the common window.  Taking differences
+    # within each waveform removes any constant initial-phase offset, so the
+    # result is independent of coalescence-phase convention.  It is NOT the
+    # same as the phase residual after match()-optimal time alignment; it uses
+    # the absolute time alignment (both waveforms referenced to t=0 at peak).
     phase_diff_per_cycle = abs(delta_phi_nr - delta_phi_sur) / n_cycles_nr
     return float(phase_diff_per_cycle), float(n_cycles_nr)
 
@@ -277,9 +283,13 @@ def mode_f_lower(f_lower: float, em: int) -> float:
     Parameters
     ----------
     f_lower : float
-        Orbital reference frequency in Hz (= half the (2,2) GW frequency).
+        GW frequency of the (2,2) mode in Hz (= 2 × orbital frequency).
+        This is what ``CatalogBase.get_parameters()`` returns as ``f_lower``.
     em : int
-        Azimuthal mode number m.
+        Azimuthal mode number m.  For m=0 the mode carries no oscillatory
+        GW power at a well-defined frequency; ``f_lower`` is returned as a
+        conservative lower bound but the result should not be interpreted as
+        a physically meaningful frequency cutoff for that mode.
 
     Returns
     -------

--- a/nrcatalogtools/waveform/modes.py
+++ b/nrcatalogtools/waveform/modes.py
@@ -879,29 +879,115 @@ class WaveformModes(sxs_WaveformModes):
         total_mass=1.0,
         distance=1.0,
     ):
-        """Calculate the match between this waveform and another, maximized
-        over time shift, phase shift, and SO(3) rotation.
+        r"""Calculate the match (noise-weighted overlap) between this waveform
+        and another, integrated over all observer directions on the sphere
+        (sky-averaged) and maximized over time shift, phase shift, and
+        active/passive SO(3) coordinate rotation of the source frame.
+
+        Mathematical Formulation
+        ------------------------
+        The full multi-mode gravitational-wave strain field $H(t, \theta, \phi) = h_+ - i h_\times$
+        as observed at polar angles $(\theta, \phi)$ in the source frame is:
+        $$
+        H(t, \theta, \phi) = \sum_{\ell=2}^{\infty} \sum_{m=-\ell}^{\ell}
+        h_{\ell m}(t) \, {}^{-2}Y_{\ell m}(\theta, \phi)
+        $$
+        where ${}^{-2}Y_{\ell m}$ are the spin-weight $-2$ spherical harmonics.
+
+        The global overlap between two waveforms $h_1$ and $h_2$, integrated over the entire
+        sphere of possible observer directions (sky locations), is defined as:
+        $$
+        \mathcal{O}_{\text{sphere}}(h_1, h_2) =
+        \frac{\int_{S^2} \langle h_1(t, \Omega) \mid h_2(t, \Omega) \rangle_t \, d\Omega}{
+        \sqrt{\left[ \int_{S^2} \langle h_1(t, \Omega) \mid h_1(t, \Omega) \rangle_t \,
+        d\Omega \right] \left[ \int_{S^2} \langle h_2(t, \Omega) \mid h_2(t, \Omega) \rangle_t \,
+        d\Omega \right]}}
+        $$
+        where $\langle \cdot \mid \cdot \rangle_t$ is the standard frequency-domain noise-weighted
+        inner product:
+        $$
+        \langle u \mid v \rangle_t = 4 \, \mathrm{Re}
+        \int_{f_{\mathrm{min}}}^{f_{\mathrm{max}}}
+        \frac{\tilde{u}(f) \, \tilde{v}^*(f)}{S_n(f)} \, df
+        $$
+
+        By utilizing the orthonormality of the spin-weighted spherical harmonics:
+        $$
+        \int_{S^2} {}^{-2}Y_{\ell m}^*(\Omega) \, {}^{-2}Y_{\ell' m'}(\Omega) \, d\Omega
+        = \delta_{\ell \ell'} \, \delta_{m m'}
+        $$
+        the angular integral decouples, simplifying the sphere-integrated inner product
+        into a simple sum over all common modes $(\ell, m)$:
+        $$
+        \int_{S^2} \langle h_1(t, \Omega) \mid h_2(t, \Omega) \rangle_t \, d\Omega
+        = \sum_{\ell, m} \langle h_{1, \ell m} \mid h_{2, \ell m} \rangle_t
+        $$
+
+        Coordinate Frame Optimization
+        -----------------------------
+        Because the two waveforms may be defined in different coordinate systems (source frames)
+        and have arbitrary reference times/phases, we align the target waveform $h_2$ to $h_1$
+        by active/passive rigid rotation $R \in SO(3)$, time translation $t_c$, and coalescence phase shift $\phi_c$:
+        1. **Rotation ($R$)**: Rotates the modes using Wigner D-matrices:
+           $$
+           h_{2, \ell m}^{\mathrm{rot}}(t) = \sum_{m'=-\ell}^{\ell} h_{2, \ell m'}(t) \, D^{\ell}_{m' m}(R)
+           $$
+
+        2. **Time Shift ($t_c$)**: Shifts time via $t \to t - t_c$,
+           implemented efficiently as a linear phase in the frequency domain.
+        3. **Phase Shift ($\phi_c$)**: Twist around the rotated $z$-axis via:
+           $$
+           h_{2, \ell m}^{\mathrm{rot, shifted}}(t) \to e^{-i m \phi_c} \, h_{2, \ell m}^{\mathrm{rot}}(t - t_c)
+           $$
+
+        The method then returns the maximized match (overlap):
+
+        $$
+        \mathcal{O}_{\mathrm{max}} = \max_{t_c, \phi_c, R \in SO(3)} \left[
+        \frac{
+            \sum_{\ell, m} \langle h_{1, \ell m} \mid
+            h_{2, \ell m}^{\mathrm{rot, shifted}}(t_c, \phi_c, R) \rangle_t
+        }{
+            \sqrt{
+                \left( \sum_{\ell, m} \langle h_{1, \ell m} \mid
+                h_{1, \ell m} \rangle_t \right)
+                \left( \sum_{\ell, m} \langle h_{2, \ell m} \mid
+                h_{2, \ell m} \rangle_t \right)
+            }
+        } \right]
+        $$
+
+        The maximization over $t_c$ is performed efficiently using Fast Fourier Transforms (FFTs),
+        $\phi_c$ is maximized analytically, and the SO(3) rotation $R$ (parameterized by
+        Euler angles $\alpha, \beta, \gamma$) is optimized using the differential evolution algorithm.
 
         Parameters
         ----------
-        other : WaveformModes
+        other : WaveformModes or dict
+            The second waveform to compare against. Can be a `WaveformModes` object or a dict
+            of PyCBC TimeSeries modes.
         psd : pycbc.types.FrequencySeries
+            One-sided noise power spectral density (PSD).
         f_lower : float
             Lower frequency cutoff in Hz.
         f_upper : float, optional
+            Upper frequency cutoff in Hz. If None, the Nyquist frequency of the PSD is used.
         delta_t : float, optional
             Sample spacing in physical seconds (default 1/4096).
         return_rotation : bool, optional
-            If True, return the optimal rotation quaternion.
+            If True, returns a tuple `(match, R_opt)` containing the maximum match and the
+            optimal quaternionic rotation.
         total_mass : float, optional
-            Total mass in solar masses (default 1.0).
+            Total mass of the binary system in solar masses (default 1.0).
         distance : float, optional
-            Luminosity distance in Mpc (default 1.0).
+            Luminosity distance to the source in Mpc (default 1.0).
 
         Returns
         -------
         float or tuple
-            Maximum match value in [0, 1] (or tuple with rotation).
+            If `return_rotation` is False, returns the maximum match value in $[0, 1]$.
+            If `return_rotation` is True, returns `(match, R_opt)` where `R_opt` is the
+            optimal `quaternionic.array` unit quaternion representing the rotation.
         """
         import numpy as np
         from scipy.optimize import differential_evolution
@@ -1062,24 +1148,65 @@ class WaveformModes(sxs_WaveformModes):
         f_upper=None,
         j_max=1,
     ):
-        """Match maximized over BMS supertranslations.
+        r"""Calculate the match maximized over BMS supertranslations in addition to
+        standard time shift, phase shift, and SO(3) rotation.
 
-        Extends ``match_sphere_averaged`` by also optimizing over the
-        coefficients of the BMS supertranslation field α(θ,φ).
+        BMS Supertranslation Mathematical Formulation
+        ---------------------------------------------
+        At null infinity $\mathcal{I}^+$, the asymptotic symmetry group of General Relativity
+        is the infinite-dimensional Bondi-Metzner-Sachs (BMS) group. This group is the
+        semi-direct product of the Lorentz group and the abelian group of **supertranslations**,
+        which correspond to direction-dependent shifts in the retarded time coordinate $u$:
+        $$
+        u' = u - \alpha(\theta, \phi)
+        $$
+        where the supertranslation field $\alpha(\theta, \phi)$ is an arbitrary smooth real
+        function on the sphere, decomposed into scalar spherical harmonics $Y_{j k}$:
+        $$
+        \alpha(\theta, \phi) = \sum_{j=0}^{j_{\mathrm{max}}} \sum_{k=-j}^{j} \alpha_{j k} \, Y_{j k}(\theta, \phi)
+        $$
+        Here, $j=0$ corresponds to a global time translation ($t_c$), $j=1$ corresponds to
+        spatial translations (origin shifts), and $j \ge 2$ modes correspond to proper
+        supertranslations.
+
+        Under a small supertranslation, the strain waveform modes $h_{\ell m}(u)$ undergo
+        first-order mode mixing:
+        $$
+        h'_{\ell m}(u) \approx h_{\ell m}(u) -
+        \sum_{j=0}^{j_{\mathrm{max}}} \sum_{k=-j}^{j} \sum_{p, q}
+        \alpha_{j k} \, \mathcal{G}^{\ell m}_{j k, p q} \, \dot{h}_{p q}(u)
+        $$
+        where $\dot{h}_{p q}(u) = \partial h_{p q} / \partial u$, and $\mathcal{G}^{\ell m}_{j k, p q}$
+        are the spin-weighted Gaunt coefficients (integrals of products of three spherical harmonics):
+        $$
+        \mathcal{G}^{\ell m}_{j k, p q} = \int_{S^2}
+        {}^{-2}Y_{\ell m}^*(\Omega) \, Y_{j k}(\Omega) \,
+        {}^{-2}Y_{p q}(\Omega) \, d\Omega
+        $$
+
+        This method optimizes both the rigid rotation $R \in SO(3)$, time translation $t_c$,
+        phase shift $\phi_c$, and the supertranslation coefficients $\alpha_{j k}$ for $j \ge 1$
+        up to `j_max` using the Nelder-Mead downhill simplex algorithm to minimize the mismatch
+        (maximize the overlap).
 
         Parameters
         ----------
         other : WaveformModes
+            The second waveform to compare against.
         psd : pycbc.types.FrequencySeries
+            One-sided noise power spectral density (PSD).
         f_lower : float
+            Lower frequency cutoff in Hz.
         f_upper : float, optional
+            Upper frequency cutoff in Hz. If None, the Nyquist frequency of the PSD is used.
         j_max : int, optional
-            Max spherical-harmonic order of the supertranslation field (default 1).
+            Maximum spherical-harmonic order of the supertranslation field to optimize
+            (default 1, which corresponds to time translation + spatial translation).
 
         Returns
         -------
         float
-            Maximum match value in [0, 1].
+            Maximum match value in $[0, 1]$.
         """
         from scipy.optimize import minimize
 

--- a/nrcatalogtools/waveform/modes.py
+++ b/nrcatalogtools/waveform/modes.py
@@ -875,6 +875,9 @@ class WaveformModes(sxs_WaveformModes):
         f_lower,
         f_upper=None,
         delta_t=1.0 / 4096,
+        return_rotation=False,
+        total_mass=1.0,
+        distance=1.0,
     ):
         """Calculate the match between this waveform and another, maximized
         over time shift, phase shift, and SO(3) rotation.
@@ -888,70 +891,168 @@ class WaveformModes(sxs_WaveformModes):
         f_upper : float, optional
         delta_t : float, optional
             Sample spacing in physical seconds (default 1/4096).
+        return_rotation : bool, optional
+            If True, return the optimal rotation quaternion.
+        total_mass : float, optional
+            Total mass in solar masses (default 1.0).
+        distance : float, optional
+            Luminosity distance in Mpc (default 1.0).
 
         Returns
         -------
-        float
-            Maximum match value in [0, 1].
+        float or tuple
+            Maximum match value in [0, 1] (or tuple with rotation).
         """
-        from scipy.optimize import minimize
+        import numpy as np
+        from scipy.optimize import differential_evolution
+        from scipy.fft import fft, ifft
+        import quaternionic
+        import spherical
+
+        # Compute overlapping frequency range
+        df = psd.delta_f
+        low_idx = int(f_lower / df) if f_lower else 0
+        high_idx = int(np.ceil(f_upper / df)) if f_upper else len(psd)
+
+        if isinstance(other, dict):
+            other_LM = list(other.keys())
+        else:
+            other_LM = list(map(tuple, other.LM))
+
+        common_modes = set(map(tuple, self.LM)) & set(other_LM)
+        if not common_modes:
+            return (0.0, None) if return_rotation else 0.0
+
+        h1_ts_dict = {}
+        h2_ts_dict = {}
+
+        # Load modes and align lengths
+        for ell, m in common_modes:
+            h1_ts_dict[(ell, m)] = self.get_mode(
+                ell,
+                m,
+                total_mass=total_mass,
+                distance=distance,
+                to_pycbc=True,
+                delta_t_seconds=delta_t,
+            )
+            if isinstance(other, dict):
+                h2_ts_dict[(ell, m)] = other[(ell, m)]
+            else:
+                h2_ts_dict[(ell, m)] = other.get_mode(
+                    ell,
+                    m,
+                    total_mass=total_mass,
+                    distance=distance,
+                    to_pycbc=True,
+                    delta_t_seconds=delta_t,
+                )
+
+        # Determine required length to match PSD's delta_f
+        N_pad = int(np.round(1.0 / (df * delta_t)))
+
+        # Build two-sided PSD array
+        psd_full = np.ones(N_pad) * np.inf
+        psd_len = N_pad // 2 + 1
+        for i in range(low_idx, min(high_idx, len(psd))):
+            if i < psd_len:
+                val = psd.data[i]
+                if val > 0:
+                    psd_full[i] = val
+                    if i > 0 and (N_pad - i) < N_pad:
+                        psd_full[N_pad - i] = val
+
+        # Compute full complex FFTs, zero-padded to N_pad
+        h1_f_dict = {}
+        h2_f_dict = {}
+        for k in common_modes:
+            ts1 = h1_ts_dict[k].data
+            ts2 = h2_ts_dict[k].data
+
+            # Zero-pad arrays to N_pad
+            pad1 = np.zeros(N_pad, dtype=complex)
+            pad2 = np.zeros(N_pad, dtype=complex)
+
+            pad1[: len(ts1)] = ts1
+            pad2[: len(ts2)] = ts2
+
+            h1_f_dict[k] = fft(pad1)
+            h2_f_dict[k] = fft(pad2)
+
+        wigner = spherical.Wigner(self.ell_max)
+        ells_in_common = set(ell for ell, m in common_modes)
 
         def objective_function(x):
-            time_shift, phi_c, alpha, beta, gamma = x
+            phi_c, alpha, beta, gamma = x
             R = quaternionic.array.from_euler_angles(alpha, beta, gamma)
-            other_rot = other.rotated(R)
+            D_full = wigner.D(R)
 
-            total_inner_prod = 0.0
             total_norm1_sq = 0.0
             total_norm2_sq = 0.0
-
-            common_modes = set(map(tuple, self.LM)) & set(map(tuple, other_rot.LM))
-
-            for ell, m in common_modes:
-                h1_mode_ts = self.get_mode(
-                    ell, m, to_pycbc=True, delta_t_seconds=delta_t
-                )
-                h2_mode_ts = other_rot.get_mode(
-                    ell, m, to_pycbc=True, delta_t_seconds=delta_t
-                )
-                if len(h1_mode_ts) > len(h2_mode_ts):
-                    h2_mode_ts.resize(len(h1_mode_ts))
-                else:
-                    h1_mode_ts.resize(len(h2_mode_ts))
-
-                psd.resize(len(h1_mode_ts.to_frequencyseries()))
-
-                h1_tilde = h1_mode_ts.to_frequencyseries(delta_f=psd.delta_f)
-                h2_tilde = h2_mode_ts.to_frequencyseries(delta_f=psd.delta_f)
-
-                h2_tilde *= np.exp(-1j * m * phi_c)
-                freqs = h2_tilde.sample_frequencies
-                h2_tilde.data *= np.exp(-2j * np.pi * freqs * time_shift)
-
-                df = psd.delta_f
-                low_idx = int(f_lower / df) if f_lower else 0
-                high_idx = int(np.ceil(f_upper / df)) if f_upper else len(psd)
-
-                h1 = h1_tilde.data[low_idx:high_idx]
-                h2 = h2_tilde.data[low_idx:high_idx]
-                psd_vals = psd.data[low_idx:high_idx]
-                psd_vals[np.isinf(psd_vals)] = 1.0
-
-                total_norm1_sq += 4 * df * np.sum((np.abs(h1) ** 2) / psd_vals)
-                total_norm2_sq += 4 * df * np.sum((np.abs(h2) ** 2) / psd_vals)
-                total_inner_prod += 4 * df * np.sum((h1 * np.conj(h2)) / psd_vals)
+            for k in common_modes:
+                total_norm1_sq += df * np.sum((np.abs(h1_f_dict[k]) ** 2) / psd_full)
+                total_norm2_sq += df * np.sum((np.abs(h2_f_dict[k]) ** 2) / psd_full)
 
             if total_norm1_sq == 0 or total_norm2_sq == 0:
                 return 1.0
 
-            overlap = np.abs(total_inner_prod) / np.sqrt(
-                total_norm1_sq * total_norm2_sq
-            )
+            I_f_full = np.zeros(N_pad, dtype=complex)
+
+            for ell in ells_in_common:
+                D_ell = np.zeros((2 * ell + 1, 2 * ell + 1), dtype=complex)
+                for i, m in enumerate(range(-ell, ell + 1)):
+                    for j, mp in enumerate(range(-ell, ell + 1)):
+                        D_ell[i, j] = D_full[wigner.Dindex(ell, m, mp)]
+
+                h2_matrix = np.zeros((N_pad, 2 * ell + 1), dtype=complex)
+                for i, m in enumerate(range(-ell, ell + 1)):
+                    if (ell, m) in h2_f_dict:
+                        h2_matrix[:, i] = h2_f_dict[(ell, m)]
+
+                h2_rot_matrix = h2_matrix @ D_ell
+
+                for j, m in enumerate(range(-ell, ell + 1)):
+                    if (ell, m) not in common_modes:
+                        continue
+                    term = (
+                        h1_f_dict[(ell, m)] * np.conj(h2_rot_matrix[:, j])
+                    ) / psd_full
+                    term *= np.exp(1j * m * phi_c)
+                    I_f_full += term
+
+            _q = ifft(I_f_full)
+            max_inner_prod = df * N_pad * np.max(np.real(_q))
+
+            overlap = max_inner_prod / np.sqrt(total_norm1_sq * total_norm2_sq)
+            if np.isnan(overlap):
+                return 1.0
+
             return 1.0 - overlap
 
-        x0 = [0.0, 0.0, 0.0, 0.0, 0.0]
-        result = minimize(objective_function, x0, method="Nelder-Mead")
-        return 1.0 - result.fun
+        bounds = [(0, 2 * np.pi), (0, 2 * np.pi), (0, np.pi), (0, 2 * np.pi)]
+
+        identity_mismatch = objective_function([0.0, 0.0, 0.0, 0.0])
+        print(
+            f"      [DEBUG] Sphere-averaged match at Identity Rotation: {1.0 - identity_mismatch:.6f}"
+        )
+
+        result = differential_evolution(
+            objective_function,
+            bounds,
+            popsize=10,
+            maxiter=50,
+            tol=1e-3,
+            mutation=(0.5, 1.0),
+            recombination=0.7,
+        )
+        match = 1.0 - result.fun
+
+        if return_rotation:
+            R_opt = quaternionic.array.from_euler_angles(
+                result.x[1], result.x[2], result.x[3]
+            )
+            return match, R_opt
+        return match
 
     def match_sphere_averaged_bms_maximized(
         self,


### PR DESCRIPTION
- [Fix FFT vectorization and amplitude scaling bugs in SO(3) match](https://github.com/gwnrtools/nrcats/commit/be97d4ad47f9dbb2a0ef66085c5cbe5e32369038)
- [Add epoch-aligned spin extraction for precessing SXS surrogates](https://github.com/gwnrtools/nrcats/commit/513f83869f4e08acc16989b0f57ad5bcaca6f3ee)
- [nrcatalogtools: align spins to heavier body, auto-rotate precessing, and update matching docs](https://github.com/gwnrtools/nrcats/commit/8c29e05db47a13c5f5ee0d6b291c1d739699933a) 
