### PR TITLE
docs: fix baseurl/repo links after gwnrtools/nr-catalog-tools -> nrcats rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ params = ritcat.get_parameters("RIT:BBH:0001-n100-id3", total_mass=60.0)
 
 ## Documentation
 
-Full documentation: **<https://gwnrtools.github.io/nr-catalog-tools/>**
+Full documentation: **<https://gwnrtools.github.io/nrcats/>**
 
 | Document | Description |
 |----------|-------------|

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,13 +1,13 @@
-# Jekyll + just-the-docs configuration for the nr-catalog-tools documentation site.
+# Jekyll + just-the-docs configuration for the nrcats documentation site.
 # Built and deployed by .github/workflows/docs.yml; see README.md for local builds.
 
-title: nr-catalog-tools
+title: nrcats
 description: >-
   A stable, unified Python interface to NR binary black-hole waveform catalogs
   for LVK analyses, waveform modeling, and cross-catalog comparison.
 url: https://gwnrtools.github.io
-baseurl: /nr-catalog-tools
-repository: gwnrtools/nr-catalog-tools
+baseurl: /nrcats
+repository: gwnrtools/nrcats
 
 theme: just-the-docs
 
@@ -41,7 +41,7 @@ search:
 heading_anchors: true
 
 aux_links:
-  nr-catalog-tools on GitHub: https://github.com/gwnrtools/nr-catalog-tools
+  nrcats on GitHub: https://github.com/gwnrtools/nrcats
 aux_links_new_tab: true
 
 nav_enabled: true
@@ -62,8 +62,8 @@ callouts:
 
 # Footer
 footer_content: >-
-  Copyright &copy; the nr-catalog-tools developers.
-  Distributed under the <a href="https://github.com/gwnrtools/nr-catalog-tools/blob/master/LICENSE">GPL license</a>.
+  Copyright &copy; the nrcats developers.
+  Distributed under the <a href="https://github.com/gwnrtools/nrcats/blob/master/LICENSE">GPL license</a>.
 
 # ── kramdown ────────────────────────────────────────────────────────────────
 # math_engine mathjax: kramdown extracts $$...$$ spans/blocks and emits

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,7 +7,7 @@ has_toc: false
 
 # API Reference
 
-Generated from source docstrings by [`bin/generate_api_docs.py`](https://github.com/gwnrtools/nr-catalog-tools/blob/master/bin/generate_api_docs.py),
+Generated from source docstrings by [`bin/generate_api_docs.py`](https://github.com/gwnrtools/nrcats/blob/master/bin/generate_api_docs.py),
 which statically analyses the package with [griffe](https://mkdocstrings.github.io/griffe/)
 (no runtime imports, so heavy dependencies are not needed to build the docs).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,7 +17,7 @@ nav_order: 11
 ## Development setup
 
 ```bash
-git clone https://github.com/gwnrtools/nr-catalog-tools.git
+git clone https://github.com/gwnrtools/nrcats.git
 cd nr-catalog-tools
 
 # Option A: conda (recommended — ships lalsuite prebuilt)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ waveform catalogs — for LVK analyses, waveform modeling, and cross-catalog com
 
 [Install](installation.md){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [Quick start](#quick-start){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[View on GitHub](https://github.com/gwnrtools/nr-catalog-tools){: .btn .fs-5 .mb-4 .mb-md-0 }
+[View on GitHub](https://github.com/gwnrtools/nrcats){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,16 +33,16 @@ pip install nr-catalog-tools
 Or, for the latest development version:
 
 ```bash
-pip install git+https://github.com/gwnrtools/nr-catalog-tools.git
+pip install git+https://github.com/gwnrtools/nrcats.git
 ```
 
 ## Install with conda
 
-The repository ships an [`environment.yml`](https://github.com/gwnrtools/nr-catalog-tools/blob/master/environment.yml)
+The repository ships an [`environment.yml`](https://github.com/gwnrtools/nrcats/blob/master/environment.yml)
 that creates a complete environment (including `lalsuite` from conda-forge):
 
 ```bash
-git clone https://github.com/gwnrtools/nr-catalog-tools.git
+git clone https://github.com/gwnrtools/nrcats.git
 cd nr-catalog-tools
 conda env create -f environment.yml
 conda activate nrcat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/gwnrtools/nr-catalog-tools"
+Homepage = "https://github.com/gwnrtools/nrcats"
 
 [project.optional-dependencies]
 # API-reference generation only; the site itself is built with Jekyll


### PR DESCRIPTION
The Jekyll site's baseurl (and title/repository/footer/aux_links) were still pointing at the pre-rename repo name, so every asset and internal nav link 404'd on the live site (served at /nrcats/, not /nr-catalog-tools/). Update _config.yml plus the handful of hardcoded GitHub/Pages URLs in docs/installation.md, docs/contributing.md, docs/index.md, docs/api/index.md, README.md, and pyproject.toml's Homepage. Verified with a local Jekyll build that all emitted asset and nav paths now resolve under /nrcats/.