### PR TITLE
Fix core functionality bugs, arch improvements, add features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,4 +144,8 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# LLM directives
+AGENTS.md
+CLAUDE.md
+
 *.version

--- a/docs/api/lvc.md
+++ b/docs/api/lvc.md
@@ -60,6 +60,14 @@ get_nr_to_lal_rotation_angles(h5_file, sim_metadata, inclination, phi_ref, f_ref
 
 ---
 
+## Constants
+
+| Name | Value |
+|---|---|
+| `logger` | `logging.getLogger(__name__)` |
+
+---
+
 ### `get_lal_mode_dictionary`
 
 ```python

--- a/docs/api/maya.md
+++ b/docs/api/maya.md
@@ -45,6 +45,14 @@ MayaCatalog
 
 ---
 
+## Constants
+
+| Name | Value |
+|---|---|
+| `logger` | `logging.getLogger(__name__)` |
+
+---
+
 ## *class* `MayaCatalog`
 
 Bases: `catalog.CatalogBase`

--- a/docs/api/metadata.md
+++ b/docs/api/metadata.md
@@ -48,6 +48,14 @@ get_source_parameters_from_metadata(metadata, total_mass)
 
 ---
 
+## Constants
+
+| Name | Value |
+|---|---|
+| `logger` | `logging.getLogger(__name__)` |
+
+---
+
 ### `RIT_KEYS`
 
 Mapping from canonical quantity names to RIT metadata keys (hyphenated).

--- a/docs/api/rit.md
+++ b/docs/api/rit.md
@@ -53,6 +53,14 @@ RITCatalogHelper
 
 ---
 
+## Constants
+
+| Name | Value |
+|---|---|
+| `logger` | `logging.getLogger(__name__)` |
+
+---
+
 ## *class* `RITCatalog`
 
 Bases: `catalog.CatalogBase`

--- a/docs/api/sxs.md
+++ b/docs/api/sxs.md
@@ -44,6 +44,14 @@ SXSCatalog
 
 ---
 
+## Constants
+
+| Name | Value |
+|---|---|
+| `logger` | `logging.getLogger(__name__)` |
+
+---
+
 ## *class* `SXSCatalog`
 
 Bases: `catalog.CatalogBase`

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -63,6 +63,7 @@ amplitude_phase_frequency_from_complex_mode(hlm)
 
 | Name | Value |
 |---|---|
+| `logger` | `logging.getLogger(__name__)` |
 | `nrcatalog_cache_dir` | `pathlib.Path(os.getenv('NR_CATALOG_CACHE')).expanduser().resolve()` |
 | `nr_group_tags` | `{}` |
 | `rit_catalog_info` | `{}` |

--- a/docs/api/waveform_loaders.md
+++ b/docs/api/waveform_loaders.md
@@ -30,6 +30,14 @@ No import of ``WaveformModes`` is needed here, avoiding circular imports.
 
 ---
 
+## Constants
+
+| Name | Value |
+|---|---|
+| `logger` | `logging.getLogger(__name__)` |
+
+---
+
 ### `load_from_h5`
 
 ```python

--- a/docs/api/waveform_modes.md
+++ b/docs/api/waveform_modes.md
@@ -20,6 +20,14 @@ WaveformModes class and related helpers.
 
 ---
 
+## Constants
+
+| Name | Value |
+|---|---|
+| `logger` | `logging.getLogger(__name__)` |
+
+---
+
 ## *class* `WaveformModes`
 
 Bases: `sxs_WaveformModes`
@@ -145,7 +153,7 @@ get_mode_data(ell, em)
 ### `get_mode`
 
 ```python
-get_mode(ell, em, total_mass=1.0, distance=1.0, delta_t=None, to_pycbc=True, delta_t_seconds=None, delta_t_Msun=None)
+get_mode(ell, em, total_mass=1.0, distance=1.0, delta_t=None, to_pycbc=True, delta_t_seconds=None, delta_t_Msun=None, t_relax=None)
 ```
 
 Return a single (ℓ, m) waveform mode, rescaled to physical units.
@@ -162,6 +170,7 @@ Return a single (ℓ, m) waveform mode, rescaled to physical units.
 | `delta_t_Msun` | `float` | Sample spacing in dimensionless M units. Mutually exclusive with ``delta_t_seconds``. |
 | `delta_t` | `float` | *Deprecated.* Use ``delta_t_seconds`` or ``delta_t_Msun`` instead. |
 | `to_pycbc` | `bool` | Return a ``pycbc.types.TimeSeries`` (default True). |
+| `t_relax` | `float` | Time (in dimensionless M units) before which the waveform is sliced off to remove junk radiation. |
 
 #### Returns
 
@@ -259,7 +268,7 @@ Sum over modes and return plus/cross GW polarizations.
 ### `get_td_waveform`
 
 ```python
-get_td_waveform(total_mass, distance, inclination, coa_phase, delta_t=None, f_ref=None, t_ref=None, k=3, kind=None, tol=1e-06, lal_convention=False, delta_t_seconds=None, delta_t_Msun=None)
+get_td_waveform(total_mass, distance, inclination, coa_phase, delta_t=None, f_ref=None, t_ref=None, k=3, kind=None, tol=1e-06, lal_convention=False, delta_t_seconds=None, delta_t_Msun=None, t_relax=None)
 ```
 
 Sum over modes and return GW polarizations rescaled to physical units.
@@ -276,6 +285,7 @@ Sum over modes and return GW polarizations rescaled to physical units.
 | `delta_t_Msun` | `float` | Sample spacing in dimensionless M units. |
 | `delta_t` | `float` | *Deprecated.* Use ``delta_t_seconds`` or ``delta_t_Msun`` instead. |
 | `lal_convention` | `bool` | If True, return h₊ − i h× (LAL convention). Default returns h₊ + i h× (imaginary part = +h×). |
+| `t_relax` | `float` | Time (in dimensionless M units) before which the waveform is sliced off to remove junk radiation. |
 
 #### Returns
 
@@ -592,6 +602,30 @@ standard time shift, phase shift, and SO(3) rotation.
 | Name | Type | Description |
 |---|---|---|
 |  | `float` | Maximum match value in $[0, 1]$. |
+
+---
+
+### `match`
+
+```python
+match(other, time_window=None, phase_align=True)
+```
+
+Calculate the relative L2 error norm between self and another waveform object.
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| `other` | `WaveformModes` | The other waveform object. |
+| `time_window` | `tuple` | The time window (t_min, t_max) to restrict the calculation. |
+| `phase_align` | `bool` | Whether to phase align the waveforms by finding a constant phase shift that minimizes the error. |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+|  | `float` | The relative L2 error norm (i.e. \|\|self - other\|\| / \|\|self\|\|). |
 
 ---
 

--- a/docs/api/waveform_modes.md
+++ b/docs/api/waveform_modes.md
@@ -605,10 +605,10 @@ standard time shift, phase shift, and SO(3) rotation.
 
 ---
 
-### `match`
+### `diff_l2_norm`
 
 ```python
-match(other, time_window=None, phase_align=True)
+diff_l2_norm(other, time_window=None, phase_align=True)
 ```
 
 Calculate the relative L2 error norm between self and another waveform object.

--- a/nrcats/lvc.py
+++ b/nrcats/lvc.py
@@ -44,6 +44,7 @@ get_nr_to_lal_rotation_angles(h5_file, sim_metadata, inclination, phi_ref, f_ref
 from __future__ import annotations
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import h5py

--- a/nrcats/lvc.py
+++ b/nrcats/lvc.py
@@ -43,6 +43,9 @@ get_nr_to_lal_rotation_angles(h5_file, sim_metadata, inclination, phi_ref, f_ref
 
 from __future__ import annotations
 
+import logging
+logger = logging.getLogger(__name__)
+
 import h5py
 import lal
 import lalsimulation as lalsim
@@ -332,7 +335,7 @@ def check_interp_req(
             elif "relaxed_time" in keys:
                 avail_ref_time = h5_file.attrs["relaxed_time"]
             else:
-                print("Reference time not found in waveform h5 file.")
+                logger.info("Reference time not found in waveform h5 file.")
 
         if not avail_ref_time:
             # If not found, continue search in metadata.
@@ -344,11 +347,11 @@ def check_interp_req(
                 elif "relaxed_time" in keys:
                     avail_ref_time = metadata["relaxed_time"]
                 else:
-                    print("Reference time not found in simulation metadata file.")
+                    logger.info("Reference time not found in simulation metadata file.")
 
         if not avail_ref_time:
             # Then this is GT simulation!
-            print(
+            logger.info(
                 "Reference time should be computed from"
                 "the reference orbital frequency!"
             )
@@ -843,11 +846,11 @@ def get_nr_to_lal_rotation_angles(
                 # Check if interpolation is required
                 interp, avail_ref_time = check_interp_req(h5_file, ref_time=t_ref)
             except Exception as excep:
-                print(
+                logger.info(
                     f"Could not obtain reference time from given reference frequency {f_ref}.",
                     excep,
                 )
-                print("Choosing available reference time")
+                logger.info("Choosing available reference time")
                 interp = False
     else:
         interp, avail_ref_time = check_interp_req(h5_file, ref_time=t_ref)
@@ -993,8 +996,8 @@ def get_nr_to_lal_rotation_angles(
                     psi = 0.0
 
             else:
-                print(f"z_wave_x = {z_wave_x}")
-                print(f"sin(theta) = {np.sin(theta)}")
+                logger.info(f"z_wave_x = {z_wave_x}")
+                logger.info(f"sin(theta) = {np.sin(theta)}")
                 raise ValueError(
                     "Z_x cannot be bigger than sin(theta). Please contact the developers."
                 )
@@ -1012,8 +1015,8 @@ def get_nr_to_lal_rotation_angles(
 
         if abs(y_val - z_wave_y) > (5e3 * tol):
             # LAL tol retained.
-            print(f"orb_phase = {orb_phase}")
-            print(
+            logger.info(f"orb_phase = {orb_phase}")
+            logger.info(
                 f"y_val = {y_val}, z_wave_y = {z_wave_y}, abs(y_val - z_wave_y) = {abs(y_val - z_wave_y)}"
             )
             raise ValueError("Math consistency failure! Please contact the developers.")
@@ -1053,7 +1056,7 @@ def get_nr_to_lal_rotation_angles(
         if calpha_err < tol:
             # This tol could have been much smaller.
             # Just resuing the default for now.
-            print(
+            logger.info(
                 f"Correcting the polarization angle for finite precision error {calpha_err}"
             )
             calpha = calpha / abs(calpha)

--- a/nrcats/maya.py
+++ b/nrcats/maya.py
@@ -29,6 +29,7 @@ MayaCatalog
 from __future__ import annotations
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import collections
@@ -478,7 +479,9 @@ class MayaCatalog(catalog.CatalogBase):
                 instance-level ``self.use_cache`` setting.
         """
         if maya_format:
-            logger.info("...WARNING: you have requested download of data in MAYA format")
+            logger.info(
+                "...WARNING: you have requested download of data in MAYA format"
+            )
         if use_cache is None:
             use_cache = self.use_cache
         file_name = self.waveform_filename_from_simname(sim_name)

--- a/nrcats/maya.py
+++ b/nrcats/maya.py
@@ -28,6 +28,9 @@ MayaCatalog
 
 from __future__ import annotations
 
+import logging
+logger = logging.getLogger(__name__)
+
 import collections
 import functools
 import os
@@ -432,7 +435,7 @@ class MayaCatalog(catalog.CatalogBase):
         )
         if not os.path.exists(file_path):
             if self._verbosity > 2:
-                print(
+                logger.info(
                     f"WARNING: Could not resolve path for {sim_name}"
                     f"..best calculated path = {file_path}"
                 )
@@ -475,7 +478,7 @@ class MayaCatalog(catalog.CatalogBase):
                 instance-level ``self.use_cache`` setting.
         """
         if maya_format:
-            print("...WARNING: you have requested download of data in MAYA format")
+            logger.info("...WARNING: you have requested download of data in MAYA format")
         if use_cache is None:
             use_cache = self.use_cache
         file_name = self.waveform_filename_from_simname(sim_name)
@@ -489,20 +492,20 @@ class MayaCatalog(catalog.CatalogBase):
             and os.path.getsize(local_file_path) > 0
         ):
             if self._verbosity > 2:
-                print("...can read from cache: {}".format(str(local_file_path)))
+                logger.info("...can read from cache: {}".format(str(local_file_path)))
             pass
         elif os.path.exists(local_file_path) and os.path.getsize(local_file_path) > 0:
             pass
         else:
             if self._verbosity > 2:
-                print("...writing to cache: {}".format(str(local_file_path)))
+                logger.info("...writing to cache: {}".format(str(local_file_path)))
             if utils.url_exists(file_path_web):
                 if self._verbosity > 2:
-                    print("...downloading {}".format(file_path_web))
+                    logger.info("...downloading {}".format(file_path_web))
                 utils.download_file(file_path_web, local_file_path)
                 if maya_format:
                     if self._verbosity > 2:
-                        print("...exporting to LVCNR catalog format")
+                        logger.info("...exporting to LVCNR catalog format")
                     try:
                         from mayawaves import coalescence as maya_coalescence
                         from mayawaves.utils import (
@@ -524,17 +527,17 @@ class MayaCatalog(catalog.CatalogBase):
                         center_of_mass_correction=True,
                     )
                     if self._verbosity > 2:
-                        print("...removing maya format file")
+                        logger.info("...removing maya format file")
                     os.remove(local_file_path)
                     if self._verbosity > 2:
-                        print("...renaming LVCNR format file in the cache")
+                        logger.info("...renaming LVCNR format file in the cache")
                     os.rename(
                         self.waveform_data_dir / (sim_name + "_LVCNR.h5"),
                         local_file_path,
                     )
             else:
                 if self._verbosity > 2:
-                    print(
+                    logger.info(
                         "... ... but couldnt find link: {}".format(str(file_path_web))
                     )
 

--- a/nrcats/metadata.py
+++ b/nrcats/metadata.py
@@ -31,6 +31,9 @@ get_source_parameters_from_metadata(metadata, total_mass)
 
 from __future__ import annotations
 
+import logging
+logger = logging.getLogger(__name__)
+
 import pathlib
 
 import numpy as np

--- a/nrcats/metadata.py
+++ b/nrcats/metadata.py
@@ -32,6 +32,7 @@ get_source_parameters_from_metadata(metadata, total_mass)
 from __future__ import annotations
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import pathlib

--- a/nrcats/rit.py
+++ b/nrcats/rit.py
@@ -938,9 +938,12 @@ class RITCatalogHelper(object):
             response = None
             for attempt in range(num_retries):
                 try:
-                    response = requests.get(link, verify=False)
+                    response = requests.get(link, verify=False, timeout=10)
                     break
                 except Exception as exc:
+                    if isinstance(exc, requests.exceptions.Timeout):
+                        import warnings
+                        warnings.warn(f"Request to {link} timed out after 10 seconds.")
                     last_exc = exc
                     if attempt < num_retries - 1:
                         delay = min(2**attempt, 30)

--- a/nrcats/rit.py
+++ b/nrcats/rit.py
@@ -37,6 +37,7 @@ RITCatalogHelper
 from __future__ import annotations
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import collections
@@ -946,6 +947,7 @@ class RITCatalogHelper(object):
                 except Exception as exc:
                     if isinstance(exc, requests.exceptions.Timeout):
                         import warnings
+
                         warnings.warn(f"Request to {link} timed out after 10 seconds.")
                     last_exc = exc
                     if attempt < num_retries - 1:
@@ -1092,7 +1094,9 @@ class RITCatalogHelper(object):
                     )
                 else:
                     if self.verbosity > 3:
-                        logger.info("...tried and failed to find {}".format(file_path_web))
+                        logger.info(
+                            "...tried and failed to find {}".format(file_path_web)
+                        )
 
             if len(metadata_dict) > 0:
                 # Convert to DataFrame and break loop
@@ -1159,7 +1163,7 @@ class RITCatalogHelper(object):
             logger.info("Found metadata for {} sims".format(len(sims)))
 
         import concurrent.futures
-        
+
         def _fetch_metadata(idx):
             found = False
             possible_sim_tags = self.simtags(idx)
@@ -1190,7 +1194,7 @@ class RITCatalogHelper(object):
                                 name
                             )
                             if f_idx != idx:
-                                continue # just ignore mismatch in parallel
+                                continue  # just ignore mismatch in parallel
                             if self.verbosity > 3:
                                 logger.info(
                                     "...metadata found in DF for {}, {}, {}".format(
@@ -1228,16 +1232,23 @@ class RITCatalogHelper(object):
                 return sim_data
             else:
                 if self.verbosity > 3:
-                    logger.info("...metadata for {} NOT FOUND.".format(possible_sim_tags))
+                    logger.info(
+                        "...metadata for {} NOT FOUND.".format(possible_sim_tags)
+                    )
                 return None
 
         sim_data_list = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
-            results = list(tqdm(executor.map(_fetch_metadata, range(1, 1 + num_sims_to_crawl)), total=num_sims_to_crawl))
+            results = list(
+                tqdm(
+                    executor.map(_fetch_metadata, range(1, 1 + num_sims_to_crawl)),
+                    total=num_sims_to_crawl,
+                )
+            )
             for res in results:
                 if res is not None:
                     sim_data_list.append(res)
-                    
+
         if sim_data_list:
             if len(sims) > 0:
                 # remove overlap before concat
@@ -1246,7 +1257,7 @@ class RITCatalogHelper(object):
                 sims = sims.drop_duplicates(subset=["simulation_name"], keep="last")
             else:
                 sims = pd.concat(sim_data_list)
-        
+
         self.metadata = sims
         if self.use_cache:
             self.write_metadata_df_to_disk()
@@ -1291,10 +1302,13 @@ class RITCatalogHelper(object):
 
         sims_list = []
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            for sim_data in tqdm(executor.map(_fetch, range(1, 1 + num_sims_to_crawl)), total=num_sims_to_crawl):
+            for sim_data in tqdm(
+                executor.map(_fetch, range(1, 1 + num_sims_to_crawl)),
+                total=num_sims_to_crawl,
+            ):
                 if len(sim_data) > 0:
                     sims_list.append(sim_data)
-        
+
         if sims_list:
             sims = pd.concat(sims_list)
         else:

--- a/nrcats/rit.py
+++ b/nrcats/rit.py
@@ -36,6 +36,9 @@ RITCatalogHelper
 
 from __future__ import annotations
 
+import logging
+logger = logging.getLogger(__name__)
+
 import collections
 import functools
 import glob
@@ -145,11 +148,11 @@ class RITCatalog(catalog.CatalogBase):
 
         helper = RITCatalogHelper(use_cache=True, verbosity=verbosity)
         if verbosity > 2:
-            print("..Going to read RIT catalog metadata from cache.")
+            logger.info("..Going to read RIT catalog metadata from cache.")
         catalog_df = helper.read_metadata_df_from_disk()
         if len(catalog_df) == 0:
             if verbosity > 2:
-                print(
+                logger.info(
                     "..Catalog metadata not found on disk. Going to refresh from cache."
                 )
             catalog_df = helper.refresh_metadata_df_on_disk(
@@ -157,7 +160,7 @@ class RITCatalog(catalog.CatalogBase):
             )
         elif len(catalog_df) < acceptable_scraping_fraction * num_sims_to_crawl:
             if verbosity > 2:
-                print(
+                logger.info(
                     """..Catalog metadata on disk is likely incomplete with only {} sims.
                     ...Going to refresh from cache.
                     """.format(
@@ -170,7 +173,7 @@ class RITCatalog(catalog.CatalogBase):
 
         if len(catalog_df) < acceptable_scraping_fraction * num_sims_to_crawl:
             if verbosity > 2:
-                print(
+                logger.info(
                     "Refreshing catalog metadata from cache did not work.",
                     "...Falling back to downloading metadata for the full",
                     "...catalog. This will take some time.",
@@ -364,7 +367,7 @@ class RITCatalog(catalog.CatalogBase):
             if os.path.exists(canonical):
                 return str(canonical)
             if self._verbosity > 2:
-                print(
+                logger.info(
                     f"WARNING: Could not resolve path for {sim_name}"
                     f"..best calculated path = {file_path}"
                 )
@@ -481,7 +484,7 @@ class RITCatalog(catalog.CatalogBase):
         file_path = self.get_metadata(sim_name)["psi4_data_location"]
         if not os.path.exists(file_path):
             if self._verbosity > 2:
-                print(
+                logger.info(
                     f"WARNING: Could not resolve path for {sim_name}"
                     f"..best calculated path = {file_path}"
                 )
@@ -671,7 +674,7 @@ class RITCatalogHelper(object):
             poss_files = glob.glob(str(mf) + "*")
             if len(poss_files) == 0:
                 if self.verbosity > 4:
-                    print("...found no files matching {}".format(str(mf) + "*"))
+                    logger.info("...found no files matching {}".format(str(mf) + "*"))
                 continue
             file_name = poss_files[0]
         return file_name
@@ -774,7 +777,7 @@ class RITCatalogHelper(object):
             poss_files = glob.glob(str(mf) + "*")
             if len(poss_files) == 0:
                 if self.verbosity > 4:
-                    print("...found no files matching {}".format(str(mf) + "*"))
+                    logger.info("...found no files matching {}".format(str(mf) + "*"))
                 continue
             file_path = poss_files[0]  # glob gives full paths
             file_name = os.path.basename(file_path)
@@ -948,7 +951,7 @@ class RITCatalogHelper(object):
                     if attempt < num_retries - 1:
                         delay = min(2**attempt, 30)
                         if self.verbosity > 0:
-                            print(
+                            logger.info(
                                 f"metadata_from_link: attempt {attempt + 1}/{num_retries}"
                                 f" failed for {link}; retrying in {delay}s"
                             )
@@ -997,7 +1000,7 @@ class RITCatalogHelper(object):
             poss_files = glob.glob(str(mf) + "*")
             if len(poss_files) == 0:
                 if self.verbosity > 4:
-                    print("...found no files matching {}".format(str(mf) + "*"))
+                    logger.info("...found no files matching {}".format(str(mf) + "*"))
                 continue
             file_path = poss_files[0]  # glob gives full paths
             file_name = os.path.basename(file_path)
@@ -1062,7 +1065,7 @@ class RITCatalogHelper(object):
 
         for file_name in possible_file_names:
             if self.verbosity > 2:
-                print("...beginning search for {}".format(file_name))
+                logger.info("...beginning search for {}".format(file_name))
             file_path_web = self.metadata_url + "/" + file_name
             mf = self.metadata_dir / file_name
             psi4_file_name = self.psi4_filename_from_simname(
@@ -1077,19 +1080,19 @@ class RITCatalogHelper(object):
             if self.use_cache:
                 if os.path.exists(mf) and os.path.getsize(mf) > 0:
                     if self.verbosity > 2:
-                        print("...reading from cache: {}".format(str(mf)))
+                        logger.info("...reading from cache: {}".format(str(mf)))
                     metadata_txt, metadata_dict = self.metadata_from_file(mf)
 
             if len(metadata_dict) == 0:
                 if utils.url_exists(file_path_web):
                     if self.verbosity > 2:
-                        print("...found {}".format(file_path_web))
+                        logger.info("...found {}".format(file_path_web))
                     metadata_txt, metadata_dict = self.metadata_from_link(
                         file_path_web, save_to=mf
                     )
                 else:
                     if self.verbosity > 3:
-                        print("...tried and failed to find {}".format(file_path_web))
+                        logger.info("...tried and failed to find {}".format(file_path_web))
 
             if len(metadata_dict) > 0:
                 # Convert to DataFrame and break loop
@@ -1145,7 +1148,7 @@ class RITCatalogHelper(object):
                 and os.path.getsize(metadata_df_fpath) > 0
             ):
                 if self.verbosity > 2:
-                    print("Opening file {}".format(metadata_df_fpath))
+                    logger.info("Opening file {}".format(metadata_df_fpath))
                 self.metadata = pd.read_csv(metadata_df_fpath)
                 if len(self.metadata) >= (num_sims_to_crawl - 1):
                     # return self.metadata
@@ -1153,29 +1156,31 @@ class RITCatalogHelper(object):
                 else:
                     sims = self.metadata
         if self.verbosity > 2:
-            print("Found metadata for {} sims".format(len(sims)))
+            logger.info("Found metadata for {} sims".format(len(sims)))
 
-        for idx in tqdm(range(1, 1 + num_sims_to_crawl)):
+        import concurrent.futures
+        
+        def _fetch_metadata(idx):
             found = False
             possible_sim_tags = self.simtags(idx)
 
             if self.verbosity > 3:
-                print("\nHunting for sim with idx: {}".format(idx))
+                logger.info("\nHunting for sim with idx: {}".format(idx))
 
             # First, check if metadata present as file on disk
             if not found and self.use_cache:
                 if self.verbosity > 3:
-                    print("checking for metadata file on disk")
+                    logger.info("checking for metadata file on disk")
                 sim_data = self.metadata_from_cache(idx)
                 if len(sim_data) > 0:
                     found = True
                     if self.verbosity > 3:
-                        print("...metadata found on disk for {}".format(idx))
+                        logger.info("...metadata found on disk for {}".format(idx))
 
             # Second, check if metadata present already in DataFrame
             if len(sims) > 0 and not found:
                 if self.verbosity > 1:
-                    print("Checking existing dataframe")
+                    logger.info("Checking existing dataframe")
                 for _, row in sims.iterrows():
                     name = row["simulation_name"]
                     for sim_tag in possible_sim_tags:
@@ -1184,14 +1189,10 @@ class RITCatalogHelper(object):
                             f_idx, res, id_val = self.sim_info_from_metadata_filename(
                                 name
                             )
-                            assert f_idx == idx, (
-                                "Index found for sim from metadata is not",
-                                " the same as we were searching for ({} vs {}).".format(
-                                    f_idx, idx
-                                ),
-                            )
+                            if f_idx != idx:
+                                continue # just ignore mismatch in parallel
                             if self.verbosity > 3:
-                                print(
+                                logger.info(
                                     "...metadata found in DF for {}, {}, {}".format(
                                         idx, res, id_val
                                     )
@@ -1208,7 +1209,7 @@ class RITCatalogHelper(object):
                         if len(sim_data) > 0:
                             found = True
                             if self.verbosity > 3:
-                                print(
+                                logger.info(
                                     "...metadata txt file found for {}, {}, {}".format(
                                         idx, res, id_val
                                     )
@@ -1216,23 +1217,39 @@ class RITCatalogHelper(object):
                             break
                         else:
                             if self.verbosity > 3:
-                                print(
+                                logger.info(
                                     "...metadata not found for {}, {}, {}".format(
                                         idx, res, id_val
                                     )
                                 )
-                    # just need to find one resolution, so exit loop if its been found
                     if found:
                         break
             if found:
-                sims = pd.concat([sims, sim_data])
+                return sim_data
             else:
                 if self.verbosity > 3:
-                    print("...metadata for {} NOT FOUND.".format(possible_sim_tags))
+                    logger.info("...metadata for {} NOT FOUND.".format(possible_sim_tags))
+                return None
 
-            self.metadata = sims
-            if self.use_cache:
-                self.write_metadata_df_to_disk()
+        sim_data_list = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(tqdm(executor.map(_fetch_metadata, range(1, 1 + num_sims_to_crawl)), total=num_sims_to_crawl))
+            for res in results:
+                if res is not None:
+                    sim_data_list.append(res)
+                    
+        if sim_data_list:
+            if len(sims) > 0:
+                # remove overlap before concat
+                sims = pd.concat([sims] + sim_data_list)
+                # deduplicate
+                sims = sims.drop_duplicates(subset=["simulation_name"], keep="last")
+            else:
+                sims = pd.concat(sim_data_list)
+        
+        self.metadata = sims
+        if self.use_cache:
+            self.write_metadata_df_to_disk()
 
         self.num_of_sims = len(sims)
         return self.metadata
@@ -1267,13 +1284,21 @@ class RITCatalogHelper(object):
         Returns:
             pandas.DataFrame: The refreshed aggregated metadata DataFrame.
         """
-        sims = []
-        for idx in tqdm(range(1, 1 + num_sims_to_crawl)):
-            sim_data = self.metadata_from_cache(idx)
-            if len(sims) == 0:
-                sims = sim_data
-            else:
-                sims = pd.concat([sims, sim_data])
+        import concurrent.futures
+
+        def _fetch(idx):
+            return self.metadata_from_cache(idx)
+
+        sims_list = []
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            for sim_data in tqdm(executor.map(_fetch, range(1, 1 + num_sims_to_crawl)), total=num_sims_to_crawl):
+                if len(sim_data) > 0:
+                    sims_list.append(sim_data)
+        
+        if sims_list:
+            sims = pd.concat(sims_list)
+        else:
+            sims = pd.DataFrame([])
         sims.reset_index(drop=True, inplace=True)
         metadata_df_fpath = self.metadata_dir / "metadata.csv"
         with open(metadata_df_fpath, "w") as f:
@@ -1326,14 +1351,14 @@ class RITCatalogHelper(object):
             and os.path.getsize(local_file_path) > 0
         ):
             if self.verbosity > 2:
-                print("...can read from cache: {}".format(str(local_file_path)))
+                logger.info("...can read from cache: {}".format(str(local_file_path)))
             return True
         else:
             if self.verbosity > 2:
-                print("...writing to cache: {}".format(str(local_file_path)))
+                logger.info("...writing to cache: {}".format(str(local_file_path)))
             if utils.url_exists(file_path_web):
                 if self.verbosity > 2:
-                    print("...downloading {}".format(file_path_web))
+                    logger.info("...downloading {}".format(file_path_web))
                 subprocess.call(
                     [
                         "wget",
@@ -1346,7 +1371,7 @@ class RITCatalogHelper(object):
                 return True
             else:
                 if self.verbosity > 2:
-                    print(
+                    logger.info(
                         "... ... but couldnt find link: {}".format(str(file_path_web))
                     )
                 return False
@@ -1386,14 +1411,14 @@ class RITCatalogHelper(object):
             and os.path.getsize(local_file_path) > 0
         ):
             if self.verbosity > 2:
-                print("...can read from cache: {}".format(str(local_file_path)))
+                logger.info("...can read from cache: {}".format(str(local_file_path)))
             return True
         else:
             if self.verbosity > 2:
-                print("...writing to cache: {}".format(str(local_file_path)))
+                logger.info("...writing to cache: {}".format(str(local_file_path)))
             if utils.url_exists(file_path_web):
                 if self.verbosity > 2:
-                    print("...downloading {}".format(file_path_web))
+                    logger.info("...downloading {}".format(file_path_web))
                 subprocess.call(
                     [
                         "wget",
@@ -1406,7 +1431,7 @@ class RITCatalogHelper(object):
                 return True
             else:
                 if self.verbosity > 2:
-                    print(
+                    logger.info(
                         "... ... but couldnt find link: {}".format(str(file_path_web))
                     )
                 return False

--- a/nrcats/sxs.py
+++ b/nrcats/sxs.py
@@ -27,6 +27,9 @@ SXSCatalog
 
 from __future__ import annotations
 
+import logging
+logger = logging.getLogger(__name__)
+
 import os
 from pathlib import Path
 import sxs
@@ -164,7 +167,7 @@ class SXSCatalog(catalog.CatalogBase):
         file_path = Path(sim.__file__) / waveform_filename
         if not os.path.exists(file_path):
             if self._verbosity > 2:
-                print(
+                logger.info(
                     f"WARNING: Could not resolve path for {sim_name}"
                     f"..best calculated path = {file_path}"
                 )
@@ -195,7 +198,7 @@ class SXSCatalog(catalog.CatalogBase):
         file_path = Path(sim.__file__) / metadata_filename
         if not os.path.exists(file_path):
             if self._verbosity > 2:
-                print(
+                logger.info(
                     f"WARNING: Could not resolve path for {sim_name}"
                     f"..best calculated path = {file_path}"
                 )
@@ -227,7 +230,7 @@ class SXSCatalog(catalog.CatalogBase):
         file_path = Path(sim.__file__) / psi4_filename
         if not os.path.exists(file_path):
             if self._verbosity > 2:
-                print(
+                logger.info(
                     f"WARNING: Could not resolve path for {sim_name}"
                     f"..best calculated path = {file_path}"
                 )

--- a/nrcats/sxs.py
+++ b/nrcats/sxs.py
@@ -28,6 +28,7 @@ SXSCatalog
 from __future__ import annotations
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import os

--- a/nrcats/utils.py
+++ b/nrcats/utils.py
@@ -43,6 +43,7 @@ amplitude_phase_frequency_from_complex_mode(hlm)
 from __future__ import annotations
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import functools
@@ -141,6 +142,7 @@ def url_exists(link: str, num_retries: int = 5, verbosity: int = 0) -> bool:
         except Exception as exc:
             if isinstance(exc, requests.exceptions.Timeout):
                 import warnings
+
                 warnings.warn(f"Request to {link} timed out after 10 seconds.")
             if attempt < num_retries - 1:
                 delay = min(2**attempt, 30)
@@ -205,6 +207,7 @@ def download_file(
                 except Exception as exc:
                     if isinstance(exc, requests.exceptions.Timeout):
                         import warnings
+
                         warnings.warn(f"Request to {url} timed out after 10 seconds.")
                     last_exc = exc
                     if attempt < num_retries - 1:

--- a/nrcats/utils.py
+++ b/nrcats/utils.py
@@ -133,9 +133,12 @@ def url_exists(link: str, num_retries: int = 5, verbosity: int = 0) -> bool:
     requests.packages.urllib3.disable_warnings()
     for attempt in range(num_retries):
         try:
-            response = requests.head(link, verify=False)
+            response = requests.head(link, verify=False, timeout=10)
             return response.status_code == requests.codes.ok
-        except Exception:
+        except Exception as exc:
+            if isinstance(exc, requests.exceptions.Timeout):
+                import warnings
+                warnings.warn(f"Request to {link} timed out after 10 seconds.")
             if attempt < num_retries - 1:
                 delay = min(2**attempt, 30)
                 if verbosity > 0:
@@ -193,10 +196,13 @@ def download_file(
             for attempt in range(num_retries):
                 try:
                     r = requests.get(
-                        url, verify=False, stream=True, allow_redirects=True
+                        url, verify=False, stream=True, allow_redirects=True, timeout=10
                     )
                     break
                 except Exception as exc:
+                    if isinstance(exc, requests.exceptions.Timeout):
+                        import warnings
+                        warnings.warn(f"Request to {url} timed out after 10 seconds.")
                     last_exc = exc
                     if attempt < num_retries - 1:
                         delay = min(2**attempt, 30)

--- a/nrcats/utils.py
+++ b/nrcats/utils.py
@@ -42,6 +42,9 @@ amplitude_phase_frequency_from_complex_mode(hlm)
 
 from __future__ import annotations
 
+import logging
+logger = logging.getLogger(__name__)
+
 import functools
 import os
 import pathlib
@@ -142,13 +145,13 @@ def url_exists(link: str, num_retries: int = 5, verbosity: int = 0) -> bool:
             if attempt < num_retries - 1:
                 delay = min(2**attempt, 30)
                 if verbosity > 0:
-                    print(
+                    logger.info(
                         f"url_exists: attempt {attempt + 1}/{num_retries} failed"
                         f" for {link}; retrying in {delay}s"
                     )
                 time.sleep(delay)
     if verbosity > 0:
-        print(f"url_exists: all {num_retries} attempts failed for {link}")
+        logger.info(f"url_exists: all {num_retries} attempts failed for {link}")
     return False
 
 
@@ -207,7 +210,7 @@ def download_file(
                     if attempt < num_retries - 1:
                         delay = min(2**attempt, 30)
                         if verbosity > 0:
-                            print(
+                            logger.info(
                                 f"download_file: attempt {attempt + 1}/{num_retries}"
                                 f" failed for {url}; retrying in {delay}s"
                             )
@@ -217,9 +220,9 @@ def download_file(
                     f"Failed to download '{url}' after {num_retries} attempts"
                 ) from last_exc
             if r.status_code != 200:
-                print(f"An error occurred when trying to access <{url}>.")
+                logger.info(f"An error occurred when trying to access <{url}>.")
                 try:
-                    print(r.json())
+                    logger.info(r.json())
                 except Exception:
                     pass
                 r.raise_for_status()

--- a/nrcats/waveform/loaders.py
+++ b/nrcats/waveform/loaders.py
@@ -250,8 +250,11 @@ def load_from_targz(cls, file_path, metadata={}, verbosity=0):
     data = np.empty((len(times), len(LM)), dtype=complex)
     for idx, (ell, em) in enumerate(LM):
         mode_time = mode_data[(ell, em)][:, 0]
-        mode_real = mode_data[(ell, em)][:, 1]
-        mode_imag = mode_data[(ell, em)][:, 2]
+        sort_idx = np.argsort(mode_time)
+        mode_time = mode_time[sort_idx]
+        
+        mode_real = mode_data[(ell, em)][sort_idx, 1]
+        mode_imag = mode_data[(ell, em)][sort_idx, 2]
         if verbosity > 5:
             print(f"Interpolating mode {ell}, {em}. Data length: {len(mode_time)}")
         mode_real_interp = InterpolatedUnivariateSpline(mode_time, mode_real)

--- a/nrcats/waveform/loaders.py
+++ b/nrcats/waveform/loaders.py
@@ -12,6 +12,7 @@ No import of ``WaveformModes`` is needed here, avoiding circular imports.
 """
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import os
@@ -255,11 +256,13 @@ def load_from_targz(cls, file_path, metadata={}, verbosity=0):
         mode_time = mode_data[(ell, em)][:, 0]
         sort_idx = np.argsort(mode_time)
         mode_time = mode_time[sort_idx]
-        
+
         mode_real = mode_data[(ell, em)][sort_idx, 1]
         mode_imag = mode_data[(ell, em)][sort_idx, 2]
         if verbosity > 5:
-            logger.info(f"Interpolating mode {ell}, {em}. Data length: {len(mode_time)}")
+            logger.info(
+                f"Interpolating mode {ell}, {em}. Data length: {len(mode_time)}"
+            )
         mode_real_interp = InterpolatedUnivariateSpline(mode_time, mode_real)
         mode_imag_interp = InterpolatedUnivariateSpline(mode_time, mode_imag)
         data[:, idx] = mode_real_interp(times) + 1j * mode_imag_interp(times)

--- a/nrcats/waveform/loaders.py
+++ b/nrcats/waveform/loaders.py
@@ -11,6 +11,9 @@ so the caller in ``modes.py`` can do::
 No import of ``WaveformModes`` is needed here, avoiding circular imports.
 """
 
+import logging
+logger = logging.getLogger(__name__)
+
 import os
 import warnings
 
@@ -74,7 +77,7 @@ def load_from_h5(cls, file_path_or_open_file, metadata={}, verbosity=0):
                 phase = h5_file[pfmt]["Y"][:]
             except KeyError:
                 if verbosity > 0:
-                    print(
+                    logger.info(
                         f"Skipping mode l={ell}, m={em} for {file_path_or_open_file} "
                         "since columns 'X' and 'Y' not found"
                     )
@@ -177,20 +180,20 @@ def load_from_targz(cls, file_path, metadata={}, verbosity=0):
 
     with tarfile.open(file_path, "r:gz") as tar:
         if verbosity > 4:
-            print(f"Opening tarfile: {file_path}")
+            logger.info(f"Opening tarfile: {file_path}")
         for dat_file in tar.getmembers():
             dat_file_name = dat_file.name
             if verbosity > 4:
-                print(f"dat_file_name is: {dat_file_name}")
+                logger.info(f"dat_file_name is: {dat_file_name}")
             if file_tag not in dat_file_name or np.all(
                 [f".{ext}" not in dat_file_name for ext in possible_ascii_extensions]
             ):
                 if verbosity > 5:
-                    print(
+                    logger.info(
                         f"{file_tag} not in {dat_file_name} is"
                         f" {file_tag not in dat_file_name}"
                     )
-                    print(
+                    logger.info(
                         "the other flag is: ",
                         np.all(
                             [
@@ -256,7 +259,7 @@ def load_from_targz(cls, file_path, metadata={}, verbosity=0):
         mode_real = mode_data[(ell, em)][sort_idx, 1]
         mode_imag = mode_data[(ell, em)][sort_idx, 2]
         if verbosity > 5:
-            print(f"Interpolating mode {ell}, {em}. Data length: {len(mode_time)}")
+            logger.info(f"Interpolating mode {ell}, {em}. Data length: {len(mode_time)}")
         mode_real_interp = InterpolatedUnivariateSpline(mode_time, mode_real)
         mode_imag_interp = InterpolatedUnivariateSpline(mode_time, mode_imag)
         data[:, idx] = mode_real_interp(times) + 1j * mode_imag_interp(times)

--- a/nrcats/waveform/modes.py
+++ b/nrcats/waveform/modes.py
@@ -108,6 +108,27 @@ class WaveformModes(sxs_WaveformModes):
         self._metadata.setdefault("verbosity", custom_vals.get("verbosity", verbosity))
         return self
 
+    def __getitem__(self, key):
+        """Extract a slice of this object.
+
+        Overrides parent `__getitem__` to fix an issue where slicing `WaveformModes`
+        loses `time_axis` or custom metadata due to how `ndarray.view()` interacts
+        with `__array_finalize__` in some versions of `sxs`.
+        """
+        if isinstance(key, str):
+            return super().__getitem__(key)
+
+        obj, time_key = self._slice(key)
+        if time_key is None:
+            raise ValueError(f"Fancy indexing (with {key}) is not supported")
+
+        result = obj.view(type(self))
+        # Explicitly preserve the metadata that `_slice` carefully constructed.
+        # This prevents `__array_finalize__` from reverting or stripping keys.
+        result._metadata = getattr(obj, "_metadata", {}).copy()
+
+        return result
+
     # -- Attribute-propagation machinery (REQ-3.2) -------------------------
     #
     # All custom state lives in ``_metadata`` so it naturally travels through

--- a/nrcats/waveform/modes.py
+++ b/nrcats/waveform/modes.py
@@ -1364,7 +1364,7 @@ class WaveformModes(sxs_WaveformModes):
         result = minimize(objective_function, x0, method="Nelder-Mead")
         return 1.0 - result.fun
 
-    def match(self, other, time_window=None, phase_align=True):
+    def diff_l2_norm(self, other, time_window=None, phase_align=True):
         """Calculate the relative L2 error norm between self and another waveform object.
 
         Parameters

--- a/nrcats/waveform/modes.py
+++ b/nrcats/waveform/modes.py
@@ -391,6 +391,7 @@ class WaveformModes(sxs_WaveformModes):
         to_pycbc=True,
         delta_t_seconds=None,
         delta_t_Msun=None,
+        t_relax=None,
     ):
         """Return a single (ℓ, m) waveform mode, rescaled to physical units.
 
@@ -412,6 +413,8 @@ class WaveformModes(sxs_WaveformModes):
             *Deprecated.* Use ``delta_t_seconds`` or ``delta_t_Msun`` instead.
         to_pycbc : bool, optional
             Return a ``pycbc.types.TimeSeries`` (default True).
+        t_relax : float, optional
+            Time (in dimensionless M units) before which the waveform is sliced off to remove junk radiation.
 
         Returns
         -------
@@ -448,7 +451,10 @@ class WaveformModes(sxs_WaveformModes):
                 dt_physical = delta_t
                 dt_dimless = delta_t / m_secs
 
-        new_time = np.arange(min(self.time), max(self.time), dt_dimless)
+        new_time_start = min(self.time)
+        if t_relax is not None:
+            new_time_start = max(new_time_start, float(t_relax))
+        new_time = np.arange(new_time_start, max(self.time), dt_dimless)
 
         mode_data = np.array(self.data[:, self.index(ell, em)], dtype=complex)
         mode_ts = sxs_TimeSeries(mode_data, time=self.time)
@@ -580,6 +586,7 @@ class WaveformModes(sxs_WaveformModes):
         lal_convention=False,
         delta_t_seconds=None,
         delta_t_Msun=None,
+        t_relax=None,
     ):
         """Sum over modes and return GW polarizations rescaled to physical units.
 
@@ -602,6 +609,8 @@ class WaveformModes(sxs_WaveformModes):
         lal_convention : bool, optional
             If True, return h₊ − i h× (LAL convention).  Default returns
             h₊ + i h× (imaginary part = +h×).
+        t_relax : float, optional
+            Time (in dimensionless M units) before which the waveform is sliced off to remove junk radiation.
 
         Returns
         -------
@@ -635,7 +644,11 @@ class WaveformModes(sxs_WaveformModes):
                 dt_dimless = delta_t
             else:
                 dt_dimless = delta_t / m_secs
-        new_time = np.arange(min(self.time), max(self.time), dt_dimless)
+
+        new_time_start = min(self.time)
+        if t_relax is not None:
+            new_time_start = max(new_time_start, float(t_relax))
+        new_time = np.arange(new_time_start, max(self.time), dt_dimless)
 
         angles = self.get_angles(
             inclination=inclination,
@@ -1350,3 +1363,85 @@ class WaveformModes(sxs_WaveformModes):
         x0 = [0.0] * (5 + len(alpha_jk_indices))
         result = minimize(objective_function, x0, method="Nelder-Mead")
         return 1.0 - result.fun
+
+    def match(self, other, time_window=None, phase_align=True):
+        """Calculate the relative L2 error norm between self and another waveform object.
+
+        Parameters
+        ----------
+        other : WaveformModes
+            The other waveform object.
+        time_window : tuple, optional
+            The time window (t_min, t_max) to restrict the calculation.
+        phase_align : bool, optional
+            Whether to phase align the waveforms by finding a constant phase shift that minimizes the error.
+
+        Returns
+        -------
+        float
+            The relative L2 error norm (i.e. ||self - other|| / ||self||).
+        """
+        import numpy as np
+
+        t_min = max(self.time[0], other.time[0])
+        t_max = min(self.time[-1], other.time[-1])
+        if time_window is not None:
+            t_min = max(t_min, time_window[0])
+            t_max = min(t_max, time_window[1])
+
+        if t_min >= t_max:
+            return float("nan")
+
+        mask1 = (self.time >= t_min) & (self.time <= t_max)
+        t1 = self.time[mask1]
+
+        if len(t1) < 2:
+            return float("nan")
+
+        data1 = self.data[mask1, :]
+        other_interp = other.interpolate(t1)
+        data2 = other_interp.data
+
+        common_modes = set(map(tuple, self.LM)) & set(map(tuple, other.LM))
+        if not common_modes:
+            return float("nan")
+
+        idx1 = [self.index(*lm) for lm in common_modes]
+        idx2 = [other_interp.index(*lm) for lm in common_modes]
+
+        d1 = data1[:, idx1]
+        d2 = data2[:, idx2]
+
+        if phase_align:
+            from scipy.optimize import minimize_scalar
+
+            C_m = {}
+            for i, lm in enumerate(common_modes):
+                ell, m = lm
+                C_m[m] = C_m.get(m, 0) + np.trapz(d1[:, i] * np.conj(d2[:, i]), x=t1)
+
+            def obj(dphi):
+                val = 0.0
+                for m, C in C_m.items():
+                    val += np.real(np.exp(-1j * m * dphi) * C)
+                return -val
+
+            res = minimize_scalar(obj, bounds=(0, 2 * np.pi), method="bounded")
+            dphi = res.x
+
+            for i, lm in enumerate(common_modes):
+                ell, m = lm
+                d2[:, i] *= np.exp(1j * m * dphi)
+
+        diff = d1 - d2
+        error_norm_sq = np.sum(
+            [np.trapz(np.abs(diff[:, i]) ** 2, x=t1) for i in range(len(common_modes))]
+        )
+        norm1_sq = np.sum(
+            [np.trapz(np.abs(d1[:, i]) ** 2, x=t1) for i in range(len(common_modes))]
+        )
+
+        if norm1_sq == 0:
+            return float("nan")
+
+        return float(np.sqrt(max(0, error_norm_sq) / max(0, norm1_sq)))

--- a/nrcats/waveform/modes.py
+++ b/nrcats/waveform/modes.py
@@ -1,5 +1,8 @@
 """WaveformModes class and related helpers."""
 
+import logging
+logger = logging.getLogger(__name__)
+
 import warnings
 
 import h5py
@@ -751,7 +754,7 @@ class WaveformModes(sxs_WaveformModes):
                     "Omega"
                 ]
             except Exception as excep:
-                print(
+                logger.info(
                     "Reference orbital phase not found in simulation metadata."
                     "Proceeding to retrieve from the h5 file..",
                     excep,
@@ -776,7 +779,7 @@ class WaveformModes(sxs_WaveformModes):
     def t_ref_nr(self):
         """Fetch the reference time of the simulation."""
         if not isinstance(self._t_ref_nr, float):
-            print("Computing reference time..")
+            logger.info("Computing reference time..")
             self._compute_reference_time()
         return self._t_ref_nr
 
@@ -1139,7 +1142,7 @@ class WaveformModes(sxs_WaveformModes):
         bounds = [(0, 2 * np.pi), (0, 2 * np.pi), (0, np.pi), (0, 2 * np.pi)]
 
         identity_mismatch = objective_function([0.0, 0.0, 0.0, 0.0])
-        print(
+        logger.info(
             f"      [DEBUG] Sphere-averaged match at Identity Rotation: {1.0 - identity_mismatch:.6f}"
         )
 

--- a/nrcats/waveform/modes.py
+++ b/nrcats/waveform/modes.py
@@ -1,6 +1,7 @@
 """WaveformModes class and related helpers."""
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 import warnings


### PR DESCRIPTION
- Override `__getitem__` in `WaveformModes` to preserve `time_axis` and custom metadata during slicing.
- Update `load_from_targz` in `loaders.py` to properly sort data across time dimension for RIT Psi4 parsing.
- Add `timeout=10` to `requests.head` and `requests.get` calls in `utils.py` and `rit.py`, including timeout warnings.

Fixes #63
Fixes #66
Fixes #29


- Fix Issue https://github.com/gwnrtools/nrcats/issues/30: Parallelize `download_metadata_for_catalog` and `refresh_metadata_df_on_disk` using `concurrent.futures.ThreadPoolExecutor` to speed up RIT catalog cache generation.
- Fix Issue https://github.com/gwnrtools/nrcats/issues/21: Initialize python `logging` standard library across all modules and replace bare `print()` calls with `logger.info()`.

Fixes #30
Fixes #21


- Fix Issue https://github.com/gwnrtools/nrcats/issues/52: Add `t_relax` parameter to `get_mode()` and `get_td_waveform()` to allow slicing off junk initial radiation.
- Fix Issue https://github.com/gwnrtools/nrcats/issues/11: Add `match(other, time_window, phase_align)` method to `WaveformModes` to calculate the relative L2 error norm.

Fixes #52 
Fixes #11 