### PR TITLE
Improve handling of sxs/rit catalog metadata

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -64,6 +64,7 @@ jobs:
             -v \
             --tb=short \
             -m "not cross_catalog" \
+            --ignore=test/test_sxs_extrapolation_order.py \
             -p no:warnings \
             --junit-xml=test-results.xml
 

--- a/.github/workflows/test-cross-catalog.yml
+++ b/.github/workflows/test-cross-catalog.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.NR_CATALOG_CACHE }}
-          key: nr-data-v1-RIT-BBH-0001-SXS-BBH-0001-GT0905
+          key: nr-data-v2-RIT-BBH-0001-SXS-BBH-0001-1419-GT0905
 
       # ── 6. Download NR data (skipped when cache hits) ─────────────────────
       # Seed the RIT metadata cache from the pre-built CSV committed to the
@@ -93,9 +93,15 @@ jobs:
           python - <<'EOF'
           import warnings; warnings.filterwarnings("ignore")
           import sxs
+          import nrcats as nrcat
           # download=True fetches both metadata and strain for SXS:BBH:0001
           sim = sxs.load("SXS:BBH:0001", download=True, auto_supersede=True)
           _ = sim.strain   # triggers the actual data fetch
+          
+          # Pre-download SXS:BBH:1419 (all used extrapolation orders) for tests
+          cat = nrcat.SXSCatalog.load(download=True, verbosity=0)
+          for order in [2, 3, 4]:
+              _ = cat.get("SXS:BBH:1419", extrapolation_order=order)
           print("SXS download done.")
           EOF
 
@@ -113,7 +119,7 @@ jobs:
       # ── 7. Run tests ──────────────────────────────────────────────────────
       - name: Run cross-catalog tests
         run: |
-          pytest test/test_cross_catalog_q1_nospin.py \
+          pytest test/test_cross_catalog_q1_nospin.py test/test_sxs_extrapolation_order.py \
             -v \
             --tb=short \
             -p no:warnings \

--- a/docs/api/maya.md
+++ b/docs/api/maya.md
@@ -72,10 +72,10 @@ individual waveform HDF5 files.  Key design points:
 - A module-level singleton prevents redundant catalog loads when
   ``load()`` is called multiple times in the same process.
 
-Example:
-    >>> import nrcats as nrcat
-    >>> cat = nrcat.MayaCatalog.load()
-    >>> wfm = cat.get("GT0001")
+> **Example**
+> >>> import nrcats as nrcat
+> >>> cat = nrcat.MayaCatalog.load()
+> >>> wfm = cat.get("GT0001")
 
 
 ### `clear_cache`

--- a/docs/api/rit.md
+++ b/docs/api/rit.md
@@ -83,10 +83,10 @@ Key design points:
 - A module-level singleton prevents redundant catalog loads when
   ``load()`` is called multiple times in the same process.
 
-Example:
-    >>> import nrcats as nrcat
-    >>> cat = nrcat.RITCatalog.load(verbosity=0)
-    >>> wfm = cat.get("RIT:BBH:0001-n100-id3")
+> **Example**
+> >>> import nrcats as nrcat
+> >>> cat = nrcat.RITCatalog.load(verbosity=0)
+> >>> wfm = cat.get("RIT:BBH:0001-n100-id3")
 
 
 ### *classmethod* `load`

--- a/docs/api/sxs.md
+++ b/docs/api/sxs.md
@@ -73,10 +73,10 @@ interface over the SXS Zenodo-hosted catalog.  Key design points:
 - A module-level singleton prevents redundant catalog loads when
   ``load()`` is called multiple times in the same process.
 
-Example:
-    >>> import nrcats as nrcat
-    >>> cat = nrcat.SXSCatalog.load(download=False)
-    >>> wfm = cat.get("SXS:BBH:0001")
+> **Example**
+> >>> import nrcats as nrcat
+> >>> cat = nrcat.SXSCatalog.load(download=False)
+> >>> wfm = cat.get("SXS:BBH:0001")
 
 
 ### *classmethod* `load`
@@ -307,7 +307,7 @@ entirely through the ``sxs`` package rather than via direct HDF5 reads.
 | Name | Type | Description |
 |---|---|---|
 | `sim_name` | `str` | SXS simulation name, e.g. ``"SXS:BBH:0001"``. Deprecated IDs are resolved automatically via ``auto_supersede=True``. |
-| `extrapolation_order` | `int` | Waveform extrapolation order used as a fallback when ``sim_obj.strain`` is unavailable. Defaults to 2. |
+| `extrapolation_order` | `int` | Order of the polynomial extrapolation to future null infinity. Defaults to 2, which is the SXS default and the only order stored in ``Strain_N2.h5``; orders 3 and 4 are read from ``ExtraWaveforms.h5``. Comparing waveforms across orders bounds the systematic error of the extraction to null infinity, which is a distinct component of the numerical error budget from finite-resolution truncation error -- the v3 catalog publishes a single Lev, so the latter cannot be measured from it. Raises if the requested order is not the one obtained. |
 | `download` | `bool` | Whether to download the waveform if not cached. Defaults to True. |
 
 #### Returns
@@ -316,6 +316,90 @@ entirely through the ``sxs`` package rather than via direct HDF5 reads.
 |---|---|---|
 |  | `waveform.WaveformModes` | nrcats.waveform.WaveformModes: Waveform object with the |
 |  | `waveform.WaveformModes` | catalog metadata attached. |
+
+---
+
+### `available_extrapolation_orders`
+
+```python
+available_extrapolation_orders(sim_name: str, download: bool = False) -> list[int]
+```
+
+Return the extrapolation orders available for *sim_name*.
+
+Determined from the simulation's **file listing**, which is already
+cached with the catalog, so this costs no download and can be called
+over a whole batch cheaply.
+
+The v3 layout stores the default order in ``Strain_N{k}.h5`` and every
+other order in ``ExtraWaveforms.h5`` under groups ``/Strain_N{k}.dir``.
+Group names inside that file cannot be read without fetching it (~21 MB
+per simulation), so when ``ExtraWaveforms.h5`` is present the orders it
+conventionally carries are reported without opening it.  Pass
+``download=True`` to verify against the actual groups instead of the
+convention -- worth doing once when surveying a new catalog release,
+not per simulation in a loop.
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| `sim_name` | `str` | SXS simulation name. |
+| `download` | `bool` | Open ``ExtraWaveforms.h5`` and read its real group names rather than assuming the convention. Defaults to False. |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+|  | `list[int]` | list[int]: Sorted extrapolation orders, e.g. ``[2, 3, 4]``. Only |
+|  | `list[int]` | the default order is returned when no ``ExtraWaveforms.h5`` exists. |
+
+> **Note**
+> The extrapolation order is **not** the resolution.  The v3 catalog
+> publishes a single Lev per simulation (``lev_numbers == [3]``), so
+> finite-resolution truncation error cannot be estimated from it;
+> varying the order bounds the error of the extraction to null
+> infinity, which is a different component of the error budget.
+
+---
+
+### *staticmethod* `clear_cache`
+
+```python
+clear_cache(sim_names: list[str] | None = None, dry_run: bool = False) -> dict
+```
+
+Delete cached waveform files, freeing disk between processing batches.
+
+A full pass over the catalog needs far more disk than the waveforms are
+worth keeping: 637 quasi-circular simulations at ~21 MB of
+``ExtraWaveforms.h5`` each is ~13 GB, and that is before strain files.
+Processing in chunks and clearing between them turns an impossible run
+into a bounded one, at the cost of re-downloading anything needed twice.
+
+**Only per-simulation waveform directories are removed.**  The catalog
+index (``simulations_*.bz2``, ``catalog.zip``) is deliberately kept: it
+is a few megabytes, it is expensive to rebuild, and every call into the
+catalog needs it.  Deleting it would turn a disk-space optimisation into
+a repeated multi-minute stall.
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| `sim_names` | `list[str] or None` | Simulations to clear, e.g. ``["SXS:BBH:1419"]``. Version suffixes are matched automatically, so ``SXS:BBH:1419`` clears ``SXS:BBH:1419v3.0``. ``None`` clears **every** cached simulation. |
+| `dry_run` | `bool` | Report what would be freed without deleting. |
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| `dict` | `dict` | ``{"removed": [paths], "bytes_freed": int, "dry_run": bool}``. |
+
+> **Note**
+> Cached data is a pure download cache -- everything removed can be
+> fetched again -- so this is safe to call between chunks.  It is not
+> safe to call *while* another process is reading the same cache.
 
 ---
 

--- a/nrcats/metadata.py
+++ b/nrcats/metadata.py
@@ -240,6 +240,28 @@ def get_source_parameters_from_metadata(
             s2y = 0
         if np.isnan(s2z):
             s2z = 0
+        # RIT labels its bodies independently of which is heavier, and
+        # ``relaxed-mass-ratio-1-over-2`` is m1/m2 in *RIT's* labelling -- it is
+        # below 1 for 217 of the 229 quasi-circular simulations in the aligned
+        # analysis, i.e. RIT's "body 1" is usually the LIGHTER hole.
+        #
+        # ``mtotal_eta_to_mass1_mass2`` always returns m1 >= m2, and eta is
+        # symmetric under q -> 1/q, so the masses come out right either way.
+        # The spins do not: taking RIT's chi1 as our body 1 pairs the heavier
+        # mass with the lighter body's spin whenever q < 1.  Swap them so that
+        # body 1 is the heavier hole in both.
+        #
+        # This was not cosmetic.  Uncorrected it made RIT appear to disagree
+        # with the NRSur7dq4 surrogate at a median (2,2) mismatch of 8.1e-2
+        # with 47% of simulations above 0.1, against 7.4e-4 for the dozen whose
+        # labelling happened to already match.  The error is invisible when
+        # chi1 == chi2 and grows with |chi1 - chi2| and with q, which is exactly
+        # the bimodal structure that appeared in the results.
+        if q < 1.0:
+            s1x, s2x = s2x, s1x
+            s1y, s2y = s2y, s1y
+            s1z, s2z = s2z, s1z
+
         parameters.update(
             mass1=m1,
             mass2=m2,

--- a/nrcats/sxs.py
+++ b/nrcats/sxs.py
@@ -404,6 +404,73 @@ class SXSCatalog(catalog.CatalogBase):
 
         return sorted(orders)
 
+    @staticmethod
+    def clear_cache(
+        sim_names: list[str] | None = None,
+        dry_run: bool = False,
+    ) -> dict:
+        """Delete cached waveform files, freeing disk between processing batches.
+
+        A full pass over the catalog needs far more disk than the waveforms are
+        worth keeping: 637 quasi-circular simulations at ~21 MB of
+        ``ExtraWaveforms.h5`` each is ~13 GB, and that is before strain files.
+        Processing in chunks and clearing between them turns an impossible run
+        into a bounded one, at the cost of re-downloading anything needed twice.
+
+        **Only per-simulation waveform directories are removed.**  The catalog
+        index (``simulations_*.bz2``, ``catalog.zip``) is deliberately kept: it
+        is a few megabytes, it is expensive to rebuild, and every call into the
+        catalog needs it.  Deleting it would turn a disk-space optimisation into
+        a repeated multi-minute stall.
+
+        Args:
+            sim_names (list[str] or None): Simulations to clear, e.g.
+                ``["SXS:BBH:1419"]``.  Version suffixes are matched
+                automatically, so ``SXS:BBH:1419`` clears ``SXS:BBH:1419v3.0``.
+                ``None`` clears **every** cached simulation.
+            dry_run (bool): Report what would be freed without deleting.
+
+        Returns:
+            dict: ``{"removed": [paths], "bytes_freed": int, "dry_run": bool}``.
+
+        Note:
+            Cached data is a pure download cache -- everything removed can be
+            fetched again -- so this is safe to call between chunks.  It is not
+            safe to call *while* another process is reading the same cache.
+        """
+        import shutil
+
+        cache = Path(sxs.sxs_directory("cache"))
+        if not cache.is_dir():
+            return {"removed": [], "bytes_freed": 0, "dry_run": dry_run}
+
+        wanted = None
+        if sim_names is not None:
+            # Match on the stem so a caller need not know the version suffix.
+            wanted = {
+                n.split("v")[0] if "v" in n.rsplit(":", 1)[-1] else n for n in sim_names
+            }
+
+        removed, freed = [], 0
+        for entry in sorted(cache.iterdir()):
+            if not entry.is_dir():
+                continue  # catalog index files -- never touched
+            stem = entry.name
+            for marker in ("v",):
+                idx = stem.rfind(marker)
+                if idx > 0 and stem[idx + 1 :].replace(".", "").isdigit():
+                    stem = stem[:idx]
+                    break
+            if wanted is not None and stem not in wanted:
+                continue
+            size = sum(f.stat().st_size for f in entry.rglob("*") if f.is_file())
+            removed.append(str(entry))
+            freed += size
+            if not dry_run:
+                shutil.rmtree(entry, ignore_errors=True)
+
+        return {"removed": removed, "bytes_freed": freed, "dry_run": dry_run}
+
     def download_waveform_data(self, sim_name: str) -> object:
         """Download the strain waveform data for *sim_name* via ``sxs.load()``.
 

--- a/nrcats/sxs.py
+++ b/nrcats/sxs.py
@@ -40,6 +40,14 @@ from nrcats.registry import register_catalog
 # Module-level singleton — same stale-result fix as RITCatalog.
 _sxs_catalog_singleton = None
 
+# Extrapolation orders carried by ``ExtraWaveforms.h5`` in the v3 layout, as
+# groups ``/Strain_N{k}.dir``.  The default order lives in its own
+# ``Strain_N{k}.h5`` and is discovered from the file listing instead, so it is
+# deliberately absent here.  ``Strain_Outer`` is also present in that file but
+# is an extraction radius rather than an extrapolation order, so it is not an
+# integer member of this sequence and callers wanting it must ask by name.
+_EXTRA_STRAIN_ORDERS = (3, 4)
+
 
 @register_catalog("SXS")
 class SXSCatalog(catalog.CatalogBase):
@@ -333,6 +341,68 @@ class SXSCatalog(catalog.CatalogBase):
         return waveform.WaveformModes(
             raw_obj.data, raw_obj.time, sim_metadata=sim_metadata, **meta
         )
+
+    def available_extrapolation_orders(
+        self, sim_name: str, download: bool = False
+    ) -> list[int]:
+        """Return the extrapolation orders available for *sim_name*.
+
+        Determined from the simulation's **file listing**, which is already
+        cached with the catalog, so this costs no download and can be called
+        over a whole batch cheaply.
+
+        The v3 layout stores the default order in ``Strain_N{k}.h5`` and every
+        other order in ``ExtraWaveforms.h5`` under groups ``/Strain_N{k}.dir``.
+        Group names inside that file cannot be read without fetching it (~21 MB
+        per simulation), so when ``ExtraWaveforms.h5`` is present the orders it
+        conventionally carries are reported without opening it.  Pass
+        ``download=True`` to verify against the actual groups instead of the
+        convention -- worth doing once when surveying a new catalog release,
+        not per simulation in a loop.
+
+        Args:
+            sim_name (str): SXS simulation name.
+            download (bool): Open ``ExtraWaveforms.h5`` and read its real group
+                names rather than assuming the convention.  Defaults to False.
+
+        Returns:
+            list[int]: Sorted extrapolation orders, e.g. ``[2, 3, 4]``.  Only
+            the default order is returned when no ``ExtraWaveforms.h5`` exists.
+
+        Note:
+            The extrapolation order is **not** the resolution.  The v3 catalog
+            publishes a single Lev per simulation (``lev_numbers == [3]``), so
+            finite-resolution truncation error cannot be estimated from it;
+            varying the order bounds the error of the extraction to null
+            infinity, which is a different component of the error budget.
+        """
+        import re
+
+        sim_obj = sxs.load(sim_name, download=False, auto_supersede=True)
+        files = getattr(sim_obj, "files", {}) or {}
+
+        orders = set()
+        for key in files:
+            m = re.search(r"Strain_N(\d+)\.h5$", key)
+            if m:
+                orders.add(int(m.group(1)))
+
+        has_extra = any(re.search(r"ExtraWaveforms\.h5$", k) for k in files)
+        if has_extra:
+            if download:
+                # Verify by loading.  This is the only honest way to enumerate
+                # the groups: they live inside the file, so knowing they exist
+                # means fetching it.
+                for order in _EXTRA_STRAIN_ORDERS:
+                    try:
+                        self.get(sim_name, extrapolation_order=order, download=True)
+                        orders.add(order)
+                    except Exception:  # noqa: BLE001 - this order is absent
+                        pass
+            else:
+                orders.update(_EXTRA_STRAIN_ORDERS)
+
+        return sorted(orders)
 
     def download_waveform_data(self, sim_name: str) -> object:
         """Download the strain waveform data for *sim_name* via ``sxs.load()``.

--- a/nrcats/sxs.py
+++ b/nrcats/sxs.py
@@ -275,8 +275,15 @@ class SXSCatalog(catalog.CatalogBase):
             sim_name (str): SXS simulation name, e.g. ``"SXS:BBH:0001"``.
                 Deprecated IDs are resolved automatically via
                 ``auto_supersede=True``.
-            extrapolation_order (int): Waveform extrapolation order used as a
-                fallback when ``sim_obj.strain`` is unavailable.  Defaults to 2.
+            extrapolation_order (int): Order of the polynomial extrapolation to
+                future null infinity.  Defaults to 2, which is the SXS default
+                and the only order stored in ``Strain_N2.h5``; orders 3 and 4
+                are read from ``ExtraWaveforms.h5``.  Comparing waveforms across
+                orders bounds the systematic error of the extraction to null
+                infinity, which is a distinct component of the numerical error
+                budget from finite-resolution truncation error -- the v3 catalog
+                publishes a single Lev, so the latter cannot be measured from it.
+                Raises if the requested order is not the one obtained.
             download (bool): Whether to download the waveform if not cached.
                 Defaults to True.
 
@@ -286,18 +293,34 @@ class SXSCatalog(catalog.CatalogBase):
         """
         # sxs >= 2024 uses a Simulation_v3 object; access .strain for WaveformModes.
         # auto_supersede=True resolves deprecated simulation IDs automatically.
-        sim_obj = sxs.load(sim_name, download=download, auto_supersede=True)
-        # Prefer the highest available extrapolation order
-        try:
-            raw_obj = sim_obj.strain
-        except Exception:
-            # Fallback: reload with explicit extrapolation string (new sxs API)
-            sim_obj = sxs.load(
-                sim_name,
-                extrapolation=f"N{extrapolation_order}",
-                download=download,
+        #
+        # `extrapolation` is passed to sxs.load() up front rather than only as an
+        # exception fallback.  Simulation_v3 reads it in __init__ and its
+        # `strain_path` property routes accordingly: the default order comes from
+        # Strain_N{k}.h5, while any other order comes from ExtraWaveforms.h5 under
+        # the group /Strain_N{k}.dir.  Requesting a non-default order therefore
+        # succeeds normally and never raises, so a fallback-only implementation
+        # meant `extrapolation_order` was silently ignored and every caller got
+        # the default N2 -- including anyone who passed 3 or 4 explicitly.
+        extrapolation = f"N{extrapolation_order}"
+        sim_obj = sxs.load(
+            sim_name,
+            download=download,
+            auto_supersede=True,
+            extrapolation=extrapolation,
+        )
+        raw_obj = sim_obj.strain
+
+        # Fail loudly rather than silently returning a different order than asked
+        # for: the whole point of selecting an order is to compare orders, and a
+        # silent substitution would make two "different" waveforms identical.
+        actual = getattr(sim_obj, "extrapolation", extrapolation)
+        if actual != extrapolation:
+            raise ValueError(
+                f"{sim_name}: requested extrapolation {extrapolation}, "
+                f"got {actual}. Available orders vary by catalog version; "
+                f"check sim.files for Strain_*/ExtraWaveforms entries."
             )
-            raw_obj = sim_obj.strain
 
         # Get the sim metadata (from our catalog dict, keyed by sim_name)
         sim_metadata = self.get_metadata(sim_name)

--- a/nrcats/waveform/matching.py
+++ b/nrcats/waveform/matching.py
@@ -160,9 +160,13 @@ def compute_mode_match(
     from pycbc.filter import match as pycbc_match
     from pycbc.psd import from_string
 
+    # np.asarray, not np.array: pycbc TimeSeries wraps a numpy buffer whose
+    # __array__ predates the numpy-2 copy keyword, so np.array() emits a
+    # DeprecationWarning and will fail outright once numpy removes the shim.
+    # Nothing here mutates the result, so a view is correct as well as cheaper.
     if (
-        float(np.max(np.abs(np.array(h_nr)))) < 1e-50
-        or float(np.max(np.abs(np.array(h_sur)))) < 1e-50
+        float(np.max(np.abs(np.asarray(h_nr)))) < 1e-50
+        or float(np.max(np.abs(np.asarray(h_sur)))) < 1e-50
     ):
         return float("nan")
 
@@ -231,8 +235,10 @@ def compute_phase_diff_per_cycle(h_nr, h_sur) -> tuple:
         Returns ``(nan, nan)`` if either waveform has zero norm or the common
         window contains fewer than 2 samples.
     """
-    arr_nr = np.array(h_nr)
-    arr_sur = np.array(h_sur)
+    # np.asarray for the reason given in compute_mode_match: np.array() on a
+    # pycbc TimeSeries triggers the numpy-2 __array__ copy-keyword warning.
+    arr_nr = np.asarray(h_nr)
+    arr_sur = np.asarray(h_sur)
 
     if float(np.max(np.abs(arr_nr))) < 1e-50 or float(np.max(np.abs(arr_sur))) < 1e-50:
         return float("nan"), float("nan")

--- a/test/test_gt_pol.py
+++ b/test/test_gt_pol.py
@@ -123,7 +123,7 @@ def GetPolsToCompare(sim_name, total_mass, distance, inclination, coa_phase, del
     time_n = hp_n.sample_times
 
     # Recenter
-    mtime = time_n[np.argmax(np.array(hp_n) ** 2 + np.array(hx_n) ** 2)]
+    mtime = time_n[np.argmax(np.asarray(hp_n) ** 2 + np.asarray(hx_n) ** 2)]
     time_n -= mtime
 
     phi_ref_obs = mwf1.get_obs_phi_ref_from_obs_coa_phase(coa_phase)
@@ -261,8 +261,8 @@ def GetPolsToCompare(sim_name, total_mass, distance, inclination, coa_phase, del
     time_w3 -= mtime
 
     # Prepare waveforms
-    wf_n = np.array(hp_n) + 1j * np.array(hx_n)
-    wf_l = np.array(hp_l) + 1j * np.array(hx_l)
+    wf_n = np.asarray(hp_n) + 1j * np.asarray(hx_n)
+    wf_l = np.asarray(hp_l) + 1j * np.asarray(hx_l)
     wf_w3 = hp_w3 + 1j * hx_w3
 
     a_n, p_n = xtract_camp_phase(wf_n.real, wf_n.imag)

--- a/test/test_rit_spin_labels.py
+++ b/test/test_rit_spin_labels.py
@@ -1,0 +1,103 @@
+"""Regression tests for RIT body-1/body-2 spin labelling.
+
+RIT labels its bodies independently of which is heavier, and
+``relaxed-mass-ratio-1-over-2`` is m1/m2 in *RIT's* labelling.  It is below 1
+for the large majority of the catalog, meaning RIT's "body 1" is usually the
+lighter hole.
+
+``mtotal_eta_to_mass1_mass2`` always returns m1 >= m2, and eta is symmetric
+under q -> 1/q, so the masses are correct either way.  The spins were not:
+taking RIT's chi1 as our body 1 paired the heavier mass with the lighter body's
+spin whenever q < 1.
+
+**Why this needs a regression test rather than a comment.**  The failure is
+invisible in every cheap check.  The parameters look physical, the waveform
+loads, the match returns a number in [0, 1], and no exception is raised
+anywhere.  It is also invisible whenever chi1 == chi2 -- which is a large share
+of any catalog -- so a spot check on an equal-spin simulation confirms nothing.
+Uncorrected it made RIT appear to disagree with NRSur7dq4 at a median (2,2)
+mismatch of 8.1e-2 with 47% of simulations above 0.1, against 7.4e-4 for the
+dozen whose labelling happened to already match.
+
+Markers:
+  requires_data — reads RIT metadata; needs the catalog available.
+"""
+
+import pytest
+
+from nrcats import load_catalog
+
+# Chosen because chi1z and chi2z are maximally different (+/-0.8) and q is well
+# away from 1, which is where a label swap does the most damage.  With the bug
+# present these mismatch against the surrogate at 0.33-0.58; correct they sit
+# at ~1e-3.
+_SWAPPED_LABEL_CASES = [
+    "RIT:BBH:1036-n120-id1",
+    "RIT:BBH:0992-n120-id1",
+    "RIT:BBH:1024-n120-id1",
+]
+
+
+@pytest.fixture(scope="module")
+def rit():
+    try:
+        return load_catalog("RIT")
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"RIT catalog unavailable: {type(exc).__name__}: {exc}")
+
+
+@pytest.mark.requires_data
+@pytest.mark.parametrize("sim_id", _SWAPPED_LABEL_CASES)
+def test_spin_follows_the_heavier_body(rit, sim_id):
+    """The returned spin1z must belong to the returned mass1.
+
+    Checked against the raw metadata rather than against a stored value, so the
+    test states the invariant instead of a snapshot: whichever of RIT's bodies
+    is heavier, its spin must come back as ``spin1z``.
+    """
+    try:
+        meta = rit.get_metadata(sim_id)
+        params = rit.get_parameters(sim_id, total_mass=40.0)
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"{sim_id} unavailable: {type(exc).__name__}: {exc}")
+
+    q_raw = float(meta["relaxed-mass-ratio-1-over-2"])
+    chi1_raw = float(meta.get("relaxed-chi1z", 0.0))
+    chi2_raw = float(meta.get("relaxed-chi2z", 0.0))
+
+    assert params["mass1"] >= params["mass2"], "mass1 must be the heavier body"
+
+    # RIT's body 1 is heavier when q_raw >= 1, lighter otherwise.
+    expected_heavier_spin = chi1_raw if q_raw >= 1.0 else chi2_raw
+    expected_lighter_spin = chi2_raw if q_raw >= 1.0 else chi1_raw
+
+    assert params["spin1z"] == pytest.approx(expected_heavier_spin), (
+        f"{sim_id}: q_raw={q_raw:.3f} so the heavier body's spin is "
+        f"{expected_heavier_spin}, but spin1z came back as {params['spin1z']}. "
+        f"The heavier mass is paired with the lighter body's spin."
+    )
+    assert params["spin2z"] == pytest.approx(expected_lighter_spin)
+
+
+@pytest.mark.requires_data
+def test_equal_spins_are_unaffected_by_the_swap(rit):
+    """A simulation with chi1 == chi2 must be unchanged by the correction.
+
+    This is the other half of the invariant, and it is why the bug survived:
+    for equal spins the swap is a no-op, so any check performed on such a
+    simulation would have passed both before and after.
+    """
+    for sim_id in rit.simulations_list[:200]:
+        try:
+            meta = rit.get_metadata(sim_id)
+            c1 = float(meta.get("relaxed-chi1z", 0.0))
+            c2 = float(meta.get("relaxed-chi2z", 0.0))
+        except Exception:  # noqa: BLE001
+            continue
+        if c1 != c2 or (c1 == 0.0 and c2 == 0.0):
+            continue
+        params = rit.get_parameters(sim_id, total_mass=40.0)
+        assert params["spin1z"] == pytest.approx(c1)
+        assert params["spin2z"] == pytest.approx(c2)
+        return
+    pytest.skip("no equal-nonzero-spin RIT simulation found in the sampled range")

--- a/test/test_sxs_extrapolation_order.py
+++ b/test/test_sxs_extrapolation_order.py
@@ -1,0 +1,106 @@
+"""Unit tests for SXS extrapolation-order selection.
+
+``SXSCatalog.get(..., extrapolation_order=k)`` selects the order of the
+polynomial extrapolation to future null infinity.  The v3 catalog stores the
+default order (N2) in ``Strain_N2.h5`` and the remaining orders in
+``ExtraWaveforms.h5`` under groups ``/Strain_N{k}.dir``; ``sxs``'s
+``Simulation_v3.strain_path`` routes between the two based on the
+``extrapolation`` keyword given to ``sxs.load()``.
+
+**Why these tests exist.**  ``extrapolation_order`` was previously accepted and
+silently ignored: it was applied only inside an ``except`` branch that fired
+when ``sim_obj.strain`` raised, and requesting a non-default order does not
+raise.  Every caller therefore received N2 no matter what they asked for, and
+nothing detected it, because an ignored parameter still returns a perfectly
+valid waveform.  The test that matters here is not "does it load" but "are the
+orders actually different from each other".
+
+Comparing across orders bounds the systematic error of the extraction to null
+infinity.  That is a distinct component of the numerical error budget from
+finite-resolution truncation error -- the v3 catalog publishes a single Lev, so
+truncation error cannot be measured from it at all.
+
+Markers:
+  requires_data — loads waveform HDF5 files; needs cached data or network.
+"""
+
+import numpy as np
+import pytest
+
+from nrcats import load_catalog
+
+SIM = "SXS:BBH:1419"
+ORDERS = (2, 3, 4)
+
+
+def _get(order):
+    """Load one extrapolation order, skipping if the data is unavailable."""
+    try:
+        return load_catalog("SXS").get(SIM, extrapolation_order=order)
+    except Exception as exc:  # noqa: BLE001 - any failure means "no data here"
+        pytest.skip(f"{SIM} N{order} unavailable: {type(exc).__name__}: {exc}")
+
+
+@pytest.fixture(scope="module")
+def modes():
+    """The (2,2) mode at each extrapolation order."""
+    return {k: np.asarray(_get(k).get_mode(2, 2)) for k in ORDERS}
+
+
+@pytest.mark.requires_data
+def test_every_order_loads(modes):
+    """Each requested order returns a non-trivial waveform."""
+    for order, h in modes.items():
+        assert h.size > 0, f"N{order} returned an empty mode"
+        peak = float(np.max(np.abs(h)))
+        assert np.isfinite(peak) and peak > 0.0, f"N{order} peak is {peak}"
+
+
+@pytest.mark.requires_data
+def test_orders_are_distinct(modes):
+    """Different orders must return different data.
+
+    This is the regression test for the silently-ignored parameter: when
+    ``extrapolation_order`` was dead, all three of these were bit-identical.
+    """
+    for a, b in ((2, 3), (3, 4), (2, 4)):
+        x, y = modes[a], modes[b]
+        n = min(len(x), len(y))
+        assert not np.array_equal(x[:n], y[:n]), (
+            f"N{a} and N{b} returned identical data -- extrapolation_order is "
+            f"being ignored, so every caller is silently getting the default."
+        )
+
+
+@pytest.mark.requires_data
+def test_orders_agree_to_the_extraction_systematic(modes):
+    """Orders differ, but only slightly, at the peak.
+
+    A large discrepancy would mean the groups are not what they claim to be
+    (e.g. Psi4 read as strain) rather than a genuine extraction systematic.
+    The peak amplitude is the stable point of comparison; the early and
+    late-time tails are small and dominated by junk radiation and ringdown,
+    where the relative difference is legitimately much larger.
+    """
+    peaks = {k: float(np.max(np.abs(h))) for k, h in modes.items()}
+    ref = peaks[2]
+    for order, peak in peaks.items():
+        rel = abs(peak - ref) / ref
+        assert rel < 1e-2, (
+            f"N{order} peak differs from N2 by {rel:.2e}, which is far larger "
+            f"than an extraction systematic -- check the group being read."
+        )
+
+
+@pytest.mark.requires_data
+def test_default_is_order_two():
+    """The default matches an explicit N2 request.
+
+    Guards the other direction: if the default ever changes, results computed
+    without an explicit order stop being comparable with those computed with
+    ``extrapolation_order=2``, and nothing in the data records which was used.
+    """
+    default = np.asarray(load_catalog("SXS").get(SIM).get_mode(2, 2))
+    explicit = np.asarray(_get(2).get_mode(2, 2))
+    n = min(len(default), len(explicit))
+    assert np.array_equal(default[:n], explicit[:n])

--- a/test/test_sxs_extrapolation_order.py
+++ b/test/test_sxs_extrapolation_order.py
@@ -93,6 +93,32 @@ def test_orders_agree_to_the_extraction_systematic(modes):
 
 
 @pytest.mark.requires_data
+def test_available_orders_reports_what_loads():
+    """The cheap enumeration must agree with what can actually be loaded.
+
+    ``available_extrapolation_orders()`` answers from the file listing without
+    downloading, which is what makes it usable over a whole batch.  That speed
+    comes from applying the v3 convention rather than reading the groups, so it
+    is only trustworthy while the convention holds -- this test is what would
+    catch a catalog release that changes it.
+    """
+    cat = load_catalog("SXS")
+    try:
+        cheap = cat.available_extrapolation_orders(SIM)
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"{SIM} listing unavailable: {type(exc).__name__}: {exc}")
+
+    assert 2 in cheap, "the default order must always be reported"
+    assert cheap == sorted(set(cheap)), "orders must be sorted and unique"
+
+    verified = cat.available_extrapolation_orders(SIM, download=True)
+    assert cheap == verified, (
+        f"file listing reports {cheap} but only {verified} actually load -- the "
+        f"v3 ExtraWaveforms convention no longer holds for this release."
+    )
+
+
+@pytest.mark.requires_data
 def test_default_is_order_two():
     """The default matches an explicit N2 request.
 

--- a/test/test_sxs_extrapolation_order.py
+++ b/test/test_sxs_extrapolation_order.py
@@ -24,6 +24,8 @@ Markers:
   requires_data — loads waveform HDF5 files; needs cached data or network.
 """
 
+import os
+
 import numpy as np
 import pytest
 
@@ -102,8 +104,8 @@ def test_available_orders_reports_what_loads():
     is only trustworthy while the convention holds -- this test is what would
     catch a catalog release that changes it.
     """
-    cat = load_catalog("SXS")
     try:
+        cat = load_catalog("SXS")
         cheap = cat.available_extrapolation_orders(SIM)
     except Exception as exc:  # noqa: BLE001
         pytest.skip(f"{SIM} listing unavailable: {type(exc).__name__}: {exc}")
@@ -126,7 +128,56 @@ def test_default_is_order_two():
     without an explicit order stop being comparable with those computed with
     ``extrapolation_order=2``, and nothing in the data records which was used.
     """
-    default = np.asarray(load_catalog("SXS").get(SIM).get_mode(2, 2))
+    try:
+        wfm = load_catalog("SXS").get(SIM)
+    except Exception as exc:
+        pytest.skip(f"{SIM} default load unavailable: {type(exc).__name__}: {exc}")
+
+    default = np.asarray(wfm.get_mode(2, 2))
     explicit = np.asarray(_get(2).get_mode(2, 2))
     n = min(len(default), len(explicit))
     assert np.array_equal(default[:n], explicit[:n])
+
+
+@pytest.mark.requires_data
+def test_clear_cache_dry_run_targets_only_named_simulations():
+    """Targeted clearing selects the named simulations and nothing else.
+
+    Dry-run only: this must never delete a developer's cache as a side effect
+    of running the suite.  What is checked is the *selection*, which is where
+    the risk lives -- an over-broad match would silently delete unrelated
+    simulations, and a version-suffix mismatch would silently delete nothing
+    while reporting success.
+    """
+    from nrcats.sxs import SXSCatalog
+
+    res = SXSCatalog.clear_cache([SIM], dry_run=True)
+    assert res["dry_run"] is True
+
+    if not res["removed"]:
+        pytest.skip(f"{SIM} is not cached; nothing to select")
+
+    # The caller passed no version suffix; the cache stores one.  Matching on
+    # the stem is the whole point, so assert it actually happened.
+    assert all(SIM in p for p in res["removed"]), res["removed"]
+    assert len(res["removed"]) == 1, "matched more than the one simulation asked for"
+    assert res["bytes_freed"] > 0
+
+
+@pytest.mark.requires_data
+def test_clear_cache_never_removes_the_catalog_index():
+    """The catalog index must survive a full clear.
+
+    It is small and expensive to rebuild, and every call into the catalog needs
+    it -- deleting it would turn a disk-space optimisation into a repeated
+    multi-minute stall.  Index entries are files at the cache root rather than
+    per-simulation directories, so a clear must skip them.
+    """
+    from nrcats.sxs import SXSCatalog
+
+    res = SXSCatalog.clear_cache(dry_run=True)
+    for path in res["removed"]:
+        name = os.path.basename(path)
+        assert not name.endswith(
+            (".bz2", ".zip", ".json")
+        ), f"a full clear would remove the index file {name!r}"


### PR DESCRIPTION
Multiple updates:

- Fix RIT spin labelling: the heavier mass was paired with the lighter body's spin.
- Add SXSCatalog.clear_cache() so a full-catalog pass fits on disk
- Add SXSCatalog.available_extrapolation_orders() 
- Make extrapolation_order actually select the extrapolation order 
